### PR TITLE
Update the contract for Compact 0.17

### DIFF
--- a/api/src/common-types.ts
+++ b/api/src/common-types.ts
@@ -21,7 +21,7 @@
 
 import { type MidnightProviders } from '@midnight-ntwrk/midnight-js-types';
 import { type FoundContract } from '@midnight-ntwrk/midnight-js-contracts';
-import type { STATE, BBoardPrivateState, Contract, Witnesses } from '../../contract/src/index';
+import type { State, BBoardPrivateState, Contract, Witnesses } from '../../contract/src/index';
 
 export const bboardPrivateStateKey = 'bboardPrivateState';
 export type PrivateStateId = typeof bboardPrivateStateKey;
@@ -81,17 +81,17 @@ export type DeployedBBoardContract = FoundContract<BBoardContract>;
  * A type that represents the derived combination of public (or ledger), and private state.
  */
 export type BBoardDerivedState = {
-  readonly state: STATE;
-  readonly instance: bigint;
+  readonly state: State;
+  readonly sequence: bigint;
   readonly message: string | undefined;
 
   /**
    * A readonly flag that determines if the current message was posted by the current user.
    *
    * @remarks
-   * The `poster` property of the public (or ledger) state is the public key of the message poster, while
+   * The `owner` property of the public (or ledger) state is the public key of the message owner, while
    * the `secretKey` property of {@link BBoardPrivateState} is the secret key of the current user. If
-   * `poster` corresponds to `secretKey`, then `isOwner` is `true`.
+   * `owner` corresponds to the public key derived from `secretKey`, then `isOwner` is `true`.
    */
   readonly isOwner: boolean;
 };

--- a/bboard-cli/src/index.ts
+++ b/bboard-cli/src/index.ts
@@ -36,7 +36,7 @@ import {
   type PrivateStateId,
   bboardPrivateStateKey,
 } from '../../api/src/index';
-import { ledger, type Ledger, STATE } from '../../contract/src/managed/bboard/contract/index.cjs';
+import { ledger, type Ledger, State } from '../../contract/src/managed/bboard/contract/index.cjs';
 import {
   type BalancedTransaction,
   createBalancedTx,
@@ -135,12 +135,12 @@ const displayLedgerState = async (
   if (ledgerState === null) {
     logger.info(`There is no bulletin board contract deployed at ${contractAddress}`);
   } else {
-    const boardState = ledgerState.state === STATE.occupied ? 'occupied' : 'vacant';
+    const boardState = ledgerState.state === State.OCCUPIED ? 'occupied' : 'vacant';
     const latestMessage = !ledgerState.message.is_some ? 'none' : ledgerState.message.value;
     logger.info(`Current state is: '${boardState}'`);
     logger.info(`Current message is: '${latestMessage}'`);
-    logger.info(`Current instance is: ${ledgerState.instance}`);
-    logger.info(`Current poster is: '${toHex(ledgerState.poster)}'`);
+    logger.info(`Current sequence is: ${ledgerState.sequence}`);
+    logger.info(`Current owner is: '${toHex(ledgerState.owner)}'`);
   }
 };
 
@@ -160,20 +160,20 @@ const displayPrivateState = async (providers: BBoardProviders, logger: Logger): 
 /* **********************************************************************
  * displayDerivedState: shows the values of derived state which is made
  * by combining the ledger state with private state. In this example, the
- * derived state compares the poster key with the private secret key to
- * determine if the current user is the poster of the current message.
+ * derived state compares the owner's key with the private secret key to
+ * determine if the current user is the owner of the current message.
  */
 
 const displayDerivedState = (ledgerState: BBoardDerivedState | undefined, logger: Logger) => {
   if (ledgerState === undefined) {
     logger.info(`No bulletin board state currently available`);
   } else {
-    const boardState = ledgerState.state === STATE.occupied ? 'occupied' : 'vacant';
-    const latestMessage = ledgerState.state === STATE.occupied ? ledgerState.message : 'none';
+    const boardState = ledgerState.state === State.OCCUPIED ? 'occupied' : 'vacant';
+    const latestMessage = ledgerState.state === State.OCCUPIED ? ledgerState.message : 'none';
     logger.info(`Current state is: '${boardState}'`);
     logger.info(`Current message is: '${latestMessage}'`);
-    logger.info(`Current instance is: ${ledgerState.instance}`);
-    logger.info(`Current poster is: '${ledgerState.isOwner ? 'you' : 'not you'}'`);
+    logger.info(`Current sequence is: ${ledgerState.sequence}`);
+    logger.info(`Current owner is: '${ledgerState.isOwner ? 'you' : 'not you'}'`);
   }
 };
 

--- a/bboard-ui/src/components/Board.tsx
+++ b/bboard-ui/src/components/Board.tsx
@@ -37,7 +37,7 @@ import { type BBoardDerivedState, type DeployedBBoardAPI } from '../../../api/sr
 import { useDeployedBoardContext } from '../hooks';
 import { type BoardDeployment } from '../contexts';
 import { type Observable } from 'rxjs';
-import { STATE } from '../../../contract/src/index';
+import { State } from '../../../contract/src/index';
 import { EmptyCardContent } from './Board.EmptyCardContent';
 
 /** The props required by the {@link Board} component. */
@@ -188,7 +188,7 @@ export const Board: React.FC<Readonly<BoardProps>> = ({ boardDeployment$ }) => {
           <CardHeader
             avatar={
               boardState ? (
-                boardState.state === STATE.vacant || (boardState.state === STATE.occupied && boardState.isOwner) ? (
+                boardState.state === State.VACANT || (boardState.state === State.OCCUPIED && boardState.isOwner) ? (
                   <LockOpenIcon data-testid="post-unlocked-icon" />
                 ) : (
                   <LockIcon data-testid="post-locked-icon" />
@@ -211,7 +211,7 @@ export const Board: React.FC<Readonly<BoardProps>> = ({ boardDeployment$ }) => {
           />
           <CardContent>
             {boardState ? (
-              boardState.state === STATE.occupied ? (
+              boardState.state === State.OCCUPIED ? (
                 <Typography data-testid="board-posted-message" minHeight={160} color="primary">
                   {boardState.message}
                 </Typography>
@@ -244,7 +244,7 @@ export const Board: React.FC<Readonly<BoardProps>> = ({ boardDeployment$ }) => {
                 <IconButton
                   title="Post message"
                   data-testid="board-post-message-btn"
-                  disabled={boardState?.state === STATE.occupied || !messagePrompt?.length}
+                  disabled={boardState?.state === State.OCCUPIED || !messagePrompt?.length}
                   onClick={onPostMessage}
                 >
                   <WriteIcon />
@@ -253,7 +253,7 @@ export const Board: React.FC<Readonly<BoardProps>> = ({ boardDeployment$ }) => {
                   title="Take down message"
                   data-testid="board-take-down-message-btn"
                   disabled={
-                    boardState?.state === STATE.vacant || (boardState?.state === STATE.occupied && !boardState.isOwner)
+                    boardState?.state === State.VACANT || (boardState?.state === State.OCCUPIED && !boardState.isOwner)
                   }
                   onClick={onDeleteMessage}
                 >

--- a/contract/src/bboard.compact
+++ b/contract/src/bboard.compact
@@ -13,43 +13,48 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pragma language_version 0.16;
+pragma language_version >= 0.16 && <= 0.17;
 
 import CompactStandardLibrary;
 
-export enum STATE { vacant, occupied }
+export enum State {
+  VACANT,
+  OCCUPIED
+}
 
-export ledger state: STATE;
+export ledger state: State;
+
 export ledger message: Maybe<Opaque<"string">>;
-export ledger instance: Counter;
-export ledger poster: Bytes<32>;
+
+export ledger sequence: Counter;
+
+export ledger owner: Bytes<32>;
 
 constructor() {
-    state = STATE.vacant;
-    message = none<Opaque<"string">>();
-    instance.increment(1);
+  state = State.VACANT;
+  message = none<Opaque<"string">>();
+  sequence.increment(1);
 }
 
 witness localSecretKey(): Bytes<32>;
 
 export circuit post(newMessage: Opaque<"string">): [] {
-    assert(state == STATE.vacant, "Attempted to post to an occupied board");
-    poster = disclose(publicKey(localSecretKey(), instance as Field as Bytes<32>));
-    message = some<Opaque<"string">>(disclose(newMessage));
-    state = STATE.occupied;
+  assert(state == State.VACANT, "Attempted to post to an occupied board");
+  owner = disclose(publicKey(localSecretKey(), sequence as Field as Bytes<32>));
+  message = disclose(some<Opaque<"string">>(newMessage));
+  state = State.OCCUPIED;
 }
 
 export circuit takeDown(): Opaque<"string"> {
-    assert(state == STATE.occupied, "Attempted to take down post from an empty board");
-    assert(poster == publicKey(localSecretKey(), instance as Field as Bytes<32>),
-        "Attempted to take down post, but not the current poster");
-    const formerMsg = message.value;
-    state = STATE.vacant;
-    instance.increment(1);
-    message = none<Opaque<"string">>();
-    return formerMsg;
+  assert(state == State.OCCUPIED, "Attempted to take down post from an empty board");
+  assert(owner == publicKey(localSecretKey(), sequence as Field as Bytes<32>), "Attempted to take down post, but not the current owner");
+  const formerMsg = message.value;
+  state = State.VACANT;
+  sequence.increment(1);
+  message = none<Opaque<"string">>();
+  return formerMsg;
 }
 
-export circuit publicKey(sk: Bytes<32>, instance: Bytes<32>): Bytes<32> {
-    return persistentHash<Vector<3, Bytes<32>>>([pad(32, "bboard:pk:"), instance, sk]);
+export circuit publicKey(sk: Bytes<32>, sequence: Bytes<32>): Bytes<32> {
+  return persistentHash<Vector<3, Bytes<32>>>([pad(32, "bboard:pk:"), sequence, sk]);
 }

--- a/contract/src/test/bboard-simulator.ts
+++ b/contract/src/test/bboard-simulator.ts
@@ -90,14 +90,14 @@ export class BBoardSimulator {
   }
 
   public publicKey(): Uint8Array {
-    const instance = convert_bigint_to_Uint8Array(
+    const sequence = convert_bigint_to_Uint8Array(
       32,
-      this.getLedger().instance,
+      this.getLedger().sequence,
     );
     return this.contract.circuits.publicKey(
       this.circuitContext,
       this.getPrivateState().secretKey,
-      instance,
+      sequence,
     ).result;
   }
 }

--- a/contract/src/test/bboard.test.ts
+++ b/contract/src/test/bboard.test.ts
@@ -20,7 +20,7 @@ import {
 } from "@midnight-ntwrk/midnight-js-network-id";
 import { describe, it, expect } from "vitest";
 import { randomBytes } from "./utils.js";
-import { STATE } from "../managed/bboard/contract/index.cjs";
+import { State } from "../managed/bboard/contract/index.cjs";
 
 setNetworkId(NetworkId.Undeployed);
 
@@ -36,11 +36,11 @@ describe("BBoard smart contract", () => {
     const key = randomBytes(32);
     const simulator = new BBoardSimulator(key);
     const initialLedgerState = simulator.getLedger();
-    expect(initialLedgerState.instance).toEqual(1n);
+    expect(initialLedgerState.sequence).toEqual(1n);
     expect(initialLedgerState.message.is_some).toEqual(false);
     expect(initialLedgerState.message.value).toEqual("");
-    expect(initialLedgerState.poster).toEqual(new Uint8Array(32));
-    expect(initialLedgerState.state).toEqual(STATE.vacant);
+    expect(initialLedgerState.owner).toEqual(new Uint8Array(32));
+    expect(initialLedgerState.state).toEqual(State.VACANT);
     const initialPrivateState = simulator.getPrivateState();
     expect(initialPrivateState).toEqual({ secretKey: key });
   });
@@ -55,11 +55,11 @@ describe("BBoard smart contract", () => {
     expect(initialPrivateState).toEqual(simulator.getPrivateState());
     // And all the correct things should have been updated in the public ledger state
     const ledgerState = simulator.getLedger();
-    expect(ledgerState.instance).toEqual(1n);
+    expect(ledgerState.sequence).toEqual(1n);
     expect(ledgerState.message.is_some).toEqual(true);
     expect(ledgerState.message.value).toEqual(message);
-    expect(ledgerState.poster).toEqual(simulator.publicKey());
-    expect(ledgerState.state).toEqual(STATE.occupied);
+    expect(ledgerState.owner).toEqual(simulator.publicKey());
+    expect(ledgerState.state).toEqual(State.OCCUPIED);
   });
 
   it("lets you take down a message", () => {
@@ -74,12 +74,12 @@ describe("BBoard smart contract", () => {
     expect(initialPrivateState).toEqual(simulator.getPrivateState());
     // And all the correct things should have been updated in the public ledger state
     const ledgerState = simulator.getLedger();
-    expect(ledgerState.instance).toEqual(2n);
+    expect(ledgerState.sequence).toEqual(2n);
     expect(ledgerState.message.is_some).toEqual(false);
     expect(ledgerState.message.value).toEqual("");
-    // Technically the circuit doesn't clear the previous poster
-    expect(ledgerState.poster).toEqual(initialPublicKey);
-    expect(ledgerState.state).toEqual(STATE.vacant);
+    // Technically the circuit doesn't clear the previous owner
+    expect(ledgerState.owner).toEqual(initialPublicKey);
+    expect(ledgerState.state).toEqual(State.VACANT);
   });
 
   it("lets you post another message after taking down the first", () => {
@@ -93,11 +93,11 @@ describe("BBoard smart contract", () => {
     expect(initialPrivateState).toEqual(simulator.getPrivateState());
     // And all the correct things should have been updated in the public ledger state
     const ledgerState = simulator.getLedger();
-    expect(ledgerState.instance).toEqual(2n);
+    expect(ledgerState.sequence).toEqual(2n);
     expect(ledgerState.message.is_some).toEqual(true);
     expect(ledgerState.message.value).toEqual(message);
-    expect(ledgerState.poster).toEqual(simulator.publicKey());
-    expect(ledgerState.state).toEqual(STATE.occupied);
+    expect(ledgerState.owner).toEqual(simulator.publicKey());
+    expect(ledgerState.state).toEqual(State.OCCUPIED);
   });
 
   it("lets a different user post a message after taking down the first", () => {
@@ -108,11 +108,11 @@ describe("BBoard smart contract", () => {
     const message = "Joy was more than just an absence of discomfort.";
     simulator.post(message);
     const ledgerState = simulator.getLedger();
-    expect(ledgerState.instance).toEqual(2n);
+    expect(ledgerState.sequence).toEqual(2n);
     expect(ledgerState.message.is_some).toEqual(true);
     expect(ledgerState.message.value).toEqual(message);
-    expect(ledgerState.poster).toEqual(simulator.publicKey());
-    expect(ledgerState.state).toEqual(STATE.occupied);
+    expect(ledgerState.owner).toEqual(simulator.publicKey());
+    expect(ledgerState.state).toEqual(State.OCCUPIED);
   });
 
   it("doesn't let the same user post twice", () => {
@@ -143,7 +143,7 @@ describe("BBoard smart contract", () => {
     );
     simulator.switchUser(randomBytes(32));
     expect(() => simulator.takeDown()).toThrow(
-      "failed assert: Attempted to take down post, but not the current poster",
+      "failed assert: Attempted to take down post, but not the current owner",
     );
   });
 });


### PR DESCRIPTION
Also, make a few tweaks and improvements:

- Run the code through the formatter
- Change the spelling of `STATE`, `vacant`, and `occupied` to match TypeScript style (specifically the Google guide)
- Move `disclose` to the value being written to the ledger
- Change the name `instance` to the more accurate `sequence`.  It's a sequence number, and "instance" is a too-generic term.
- Change the name `poster` to the less ambiguous `owner`.  "Poster" is ambiguous because people put posters on bulletin boards.