### PR TITLE
feat: adapt to new way Midnight wallet connector is injected

### DIFF
--- a/bboard-ui/src/contexts/BrowserDeployedBoardManager.ts
+++ b/bboard-ui/src/contexts/BrowserDeployedBoardManager.ts
@@ -268,13 +268,24 @@ const initializeProviders = async (logger: Logger): Promise<BBoardProviders> => 
 };
 
 /** @internal */
+const getFirstMidnightConnector = (): InitialAPI => {
+  const mw = (window as unknown as { midnight?: Record<string, InitialAPI> | undefined }).midnight;
+  if (!mw || typeof mw !== 'object') {
+    throw new Error('No Midnight wallet extension detected. Install Midnight Lace or another compatible wallet.');
+  }
+  const first = Object.values(mw)[0];
+  if (!first) throw new Error('Midnight object contains no entries.');
+  return first;
+};
+
+/** @internal */
 const connectToWallet = (logger: Logger, networkId: string): Promise<ConnectedAPI> => {
   const COMPATIBLE_CONNECTOR_API_VERSION = '4.x';
 
   return firstValueFrom(
     fnPipe(
       interval(100),
-      map(() => window.midnight?.mnLace),
+      map(() => getFirstMidnightConnector()),
       tap((connectorAPI) => {
         logger.info(connectorAPI, 'Check for wallet connector API');
       }),

--- a/contract/src/bboard.compact
+++ b/contract/src/bboard.compact
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pragma language_version 0.20;
+pragma language_version >= 0.20;
 
 import CompactStandardLibrary;
 


### PR DESCRIPTION
1. Wallet connector discovery changed in UI:
- Change: replaced hardcoded `window.midnight?.mnLace` lookup with a helper that reads the first connector under window.midnight.
- Reason: adapt to newer wallet injection model where connector key may not always be mnLace.

2. Contract pragma relaxed:
- Change: pragma language_version 0.20; -> pragma language_version >= 0.20;
- Reason: avoid strict pinning so the contract compiles with newer compatible Compact compiler versions.