### PR TITLE
feat: sealed ownership with selective disclosure (Track C capstone)

### DIFF
--- a/README-CAPSTONE.md
+++ b/README-CAPSTONE.md
@@ -1,0 +1,107 @@
+# Track C: Sealed Ownership with Selective Disclosure
+
+## What Was Built
+
+This capstone implements **ownership hiding with selective disclosure** on the Midnight bulletin board (bboard) example. The `owner` field is changed from an exported (publicly visible) ledger entry to a non-exported (hidden from the TypeScript API) ledger field. A new `revealOwnership` circuit enables selective disclosure — the owner can prove their identity through a ZK proof that reveals only a boolean (`true`/`false`), never the actual key.
+
+Before this change, the `owner` field was exported via `export ledger owner: Bytes<32>`, making the hashed public key available in the generated `Ledger` TypeScript type. Any DApp, indexer, or observer could read this hash and track which identity owned which post across time. This is a classic pseudonymity problem: the hash acts as a stable fingerprint.
+
+After this change, `owner` is a non-exported ledger field (`ledger owner: Bytes<32>` — no `export`). It remains accessible inside circuits for authorization checks, but the Compact compiler excludes it from the generated `Ledger` type. The DApp layer (API and CLI) cannot read it directly. The only way to verify ownership is through the `revealOwnership` circuit, which discloses a single boolean — nothing more.
+
+## GDPR Art. 25: Privacy by Design
+
+This implementation directly maps to **GDPR Article 25** — Data Protection by Design and by Default:
+
+- **Data minimization**: The public API no longer exposes any ownership identifier. The minimum necessary data (the message and board state) remains public; ownership is hidden by default.
+- **Purpose limitation**: Ownership data is only accessible when explicitly needed (verification via ZK proof), not broadcast to all observers through the TypeScript API.
+- **Privacy by default**: A new user interacting with the contract sees `<sealed>` for the owner field. No configuration or opt-in is required — privacy is the default state.
+
+The `revealOwnership` circuit embodies the principle of **selective disclosure**: you prove a fact about yourself (I am the owner) without revealing your secret key. This is the ZK equivalent of showing a bouncer that you're over 21 without revealing your birth date.
+
+## Compact Patterns Used
+
+### Non-Exported Ledger Fields
+
+```compact
+// BEFORE: exported — visible in generated Ledger type
+export ledger owner: Bytes<32>;
+
+// AFTER: non-exported — hidden from generated Ledger type
+ledger owner: Bytes<32>;
+```
+
+By removing `export`, the Compact compiler excludes `owner` from the generated TypeScript `Ledger` type. The field still exists in the contract's internal state and is fully accessible within circuits, but the DApp layer cannot read it. This is the simplest and most effective way to hide a field from external observers in Compact 0.21.
+
+### Why Not `sealed`? A Lesson in Compact Semantics
+
+The initial design called for `sealed ledger owner: Bytes<32>` — the intuition being that "sealed" means "private" or "hidden." This is a reasonable assumption coming from general-purpose languages or even from Solidity's access modifiers, but Compact uses `sealed` with a very specific meaning: **immutable after the constructor**, analogous to Solidity's `immutable` keyword.
+
+The Compact 0.21 compiler enforces this statically: "exported circuits cannot modify sealed ledger fields." This isn't just about exported circuits — even non-exported helper circuits called (directly or indirectly) from exported circuits are rejected. The compiler traces the full call graph to verify that no code path reachable from an exported circuit can write to a sealed field.
+
+This makes `sealed` the wrong tool for `owner`, which must change with every `post()` call. The three Compact visibility axes are:
+
+| Mechanism | Controls | Analogy |
+|-----------|----------|---------|
+| `export` on ledger field | Whether the field appears in the generated TypeScript `Ledger` type | `public` vs `private` in OOP |
+| `sealed` on ledger field | Whether the field can be written after constructor | `immutable` in Solidity |
+| `disclose()` on values | Whether witness-derived data crosses the ZK privacy boundary | explicit declassification |
+
+For our use case — a field that changes at runtime but should be invisible to DApp consumers — removing `export` is the correct and sufficient approach. It hides `owner` from the TypeScript API layer while keeping it fully accessible inside circuits for authorization (`takeDown`) and selective disclosure (`revealOwnership`).
+
+This discovery demonstrates that privacy in Compact is achieved through the interplay of multiple mechanisms, not a single keyword. The `sealed` keyword protects against mutation; non-export protects against visibility; `disclose()` controls the ZK boundary. Understanding which lever to pull — and why — is essential for building privacy-preserving contracts on Midnight.
+
+### `disclose()` Function
+
+The `disclose()` function marks where witness-derived data crosses the privacy boundary. In `post`, it remains on the owner assignment because the Compact compiler requires explicit disclosure declarations for witness-derived values written to ledger:
+
+```compact
+owner = disclose(publicKey(localSecretKey(), ...));
+```
+
+In `revealOwnership`, `disclose()` is used strategically on the boolean comparison result — only revealing yes/no, not the key:
+
+```compact
+return disclose(owner == publicKey(localSecretKey(), ...));
+```
+
+This is the core of selective disclosure: the comparison happens inside the circuit, and only the boolean result is disclosed.
+
+### Witnesses and Assertions
+
+The `localSecretKey()` witness provides the user's secret key from private state into the circuit. The `assert()` statements enforce preconditions — for example, `revealOwnership` requires the board to be occupied, and `takeDown` still verifies that the caller's derived key matches the owner.
+
+## Privacy Properties: Before vs After
+
+| Property | Before | After |
+|----------|--------|-------|
+| Owner key in Ledger type | Yes (exported) | No (non-exported) |
+| Owner readable by DApps | Yes (via `ledger.owner`) | No |
+| Ownership verification | Compare hashes client-side | ZK proof (boolean only) |
+| TakeDown authorization | Works via internal key comparison | Works identically (non-exported fields accessible in circuits) |
+| Information leaked via API | 32-byte identifier per post | Nothing (only true/false on explicit verification) |
+
+## Trade-offs
+
+1. **No passive ownership detection**: In the original design, any DApp could check the `Ledger` type to see if a given key owned the current post. With hidden ownership, this requires an active circuit call (`revealOwnership`). This is a feature, not a bug — it prevents surveillance.
+
+2. **Circuit call required for verification**: `revealOwnership` is an impure circuit, meaning on a real network it would require transaction submission and gas costs. This is the cost of privacy — verification is no longer "free" from the ledger API.
+
+3. **Derived state simplified**: The API's `BBoardDerivedState` no longer computes `isOwner` from ledger state. Instead, it reports `ownershipSealed: true` as a constant, reflecting that ownership cannot be determined from public data alone.
+
+## Limitations
+
+- The owner hash still exists in the contract's internal state — a sufficiently advanced indexer with direct access to the underlying data store could potentially extract it. Full privacy would require Compact's ZK shielded state (future feature).
+- The `revealOwnership` circuit is impure (it accesses non-exported ledger state), so it requires a transaction on-chain.
+- The boolean result of `revealOwnership` is itself public once disclosed — an observer can see that *someone* verified ownership and whether the result was true or false. However, this only reveals information about the specific caller at that specific moment, not the owner's identity.
+- The `publicKey` circuit remains exported and public. While it doesn't reveal the hidden owner, it could theoretically be used off-chain to compute a key for comparison if someone had access to the raw ledger data.
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `contract/src/bboard.compact` | Removed `export` from `owner` ledger field, added `revealOwnership` circuit, bumped language to 0.21 |
+| `contract/src/test/bboard-simulator.ts` | Replaced `publicKey()` with `revealOwnership()` method |
+| `contract/src/test/bboard.test.ts` | Updated all tests to use `revealOwnership`, added 5 new test cases |
+| `api/src/common-types.ts` | Replaced `isOwner: boolean` with `ownershipSealed: true` |
+| `api/src/index.ts` | Simplified `state$` derivation (no more `combineLatest`), added `revealOwnership()` API method |
+| `bboard-cli/src/index.ts` | Shows `<sealed>` for owner in ledger display, added menu option 7 for ZK ownership verification |

--- a/api/src/common-types.ts
+++ b/api/src/common-types.ts
@@ -79,21 +79,16 @@ export type DeployedBBoardContract = FoundContract<BBoardContract>;
 
 /**
  * A type that represents the derived combination of public (or ledger), and private state.
+ *
+ * @remarks
+ * With sealed ownership, the `owner` field is no longer visible in the public ledger.
+ * Ownership can only be verified via the `revealOwnership` ZK circuit.
  */
 export type BBoardDerivedState = {
   readonly state: State;
   readonly sequence: bigint;
   readonly message: string | undefined;
-
-  /**
-   * A readonly flag that determines if the current message was posted by the current user.
-   *
-   * @remarks
-   * The `owner` property of the public (or ledger) state is the public key of the message owner, while
-   * the `secretKey` property of {@link BBoardPrivateState} is the secret key of the current user. If
-   * `owner` corresponds to the public key derived from `secretKey`, then `isOwner` is `true`.
-   */
-  readonly isOwner: boolean;
+  readonly ownershipSealed: true;
 };
 
 // TODO: for some reason I needed to include "@midnight-ntwrk/wallet-sdk-address-format": "1.0.0-rc.1", should we bump in to rc-2 ?

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -21,7 +21,7 @@
 
 import * as BBoard from '../../contract/src/managed/bboard/contract/index.js';
 
-import { type ContractAddress, convertFieldToBytes } from '@midnight-ntwrk/compact-runtime';
+import { type ContractAddress } from '@midnight-ntwrk/compact-runtime';
 import { type Logger } from 'pino';
 import {
   type BBoardDerivedState,
@@ -33,9 +33,9 @@ import {
 import { CompiledBBoardContractContract } from '../../contract/src/index';
 import * as utils from './utils/index.js';
 import { deployContract, findDeployedContract } from '@midnight-ntwrk/midnight-js-contracts';
-import { combineLatest, map, tap, from, type Observable } from 'rxjs';
+import { map, tap, type Observable } from 'rxjs';
 import { toHex } from '@midnight-ntwrk/midnight-js-utils';
-import { BBoardPrivateState, createBBoardPrivateState } from '@midnight-ntwrk/bboard-contract';
+import { type BBoardPrivateState, createBBoardPrivateState } from '@midnight-ntwrk/bboard-contract';
 
 /** @internal */
 
@@ -48,6 +48,7 @@ export interface DeployedBBoardAPI {
 
   post: (message: string) => Promise<void>;
   takeDown: () => Promise<void>;
+  revealOwnership: () => Promise<boolean>;
 }
 
 /**
@@ -75,44 +76,27 @@ export class BBoardAPI implements DeployedBBoardAPI {
     private readonly logger?: Logger,
   ) {
     this.deployedContractAddress = deployedContract.deployTxData.public.contractAddress;
-    this.state$ = combineLatest(
-      [
-        // Combine public (ledger) state with...
-        providers.publicDataProvider.contractStateObservable(this.deployedContractAddress, { type: 'latest' }).pipe(
-          map((contractState) => BBoard.ledger(contractState.data)),
-          tap((ledgerState) =>
-            logger?.trace({
-              ledgerStateChanged: {
-                ledgerState: {
-                  ...ledgerState,
-                  state: ledgerState.state === BBoard.State.OCCUPIED ? 'occupied' : 'vacant',
-                  owner: toHex(ledgerState.owner),
-                },
+    this.state$ = providers.publicDataProvider
+      .contractStateObservable(this.deployedContractAddress, { type: 'latest' })
+      .pipe(
+        map((contractState) => BBoard.ledger(contractState.data)),
+        tap((ledgerState) =>
+          logger?.trace({
+            ledgerStateChanged: {
+              ledgerState: {
+                ...ledgerState,
+                state: ledgerState.state === BBoard.State.OCCUPIED ? 'occupied' : 'vacant',
               },
-            }),
-          ),
+            },
+          }),
         ),
-        // ...private state...
-        //    since the private state of the bulletin board application never changes, we can query the
-        //    private state once and always use the same value with `combineLatest`. In applications
-        //    where the private state is expected to change, we would need to make this an `Observable`.
-        from(providers.privateStateProvider.get(bboardPrivateStateKey) as Promise<BBoardPrivateState>),
-      ],
-      // ...and combine them to produce the required derived state.
-      (ledgerState, privateState) => {
-        const hashedSecretKey = BBoard.pureCircuits.publicKey(
-          privateState.secretKey,
-          convertFieldToBytes(32, ledgerState.sequence, 'api/src/index.ts'),
-        );
-
-        return {
+        map((ledgerState) => ({
           state: ledgerState.state,
           message: ledgerState.message.value,
           sequence: ledgerState.sequence,
-          isOwner: toHex(ledgerState.owner) === toHex(hashedSecretKey),
-        };
-      },
-    );
+          ownershipSealed: true as const,
+        })),
+      );
   }
 
   /**
@@ -168,6 +152,31 @@ export class BBoardAPI implements DeployedBBoardAPI {
         blockHeight: txData.public.blockHeight,
       },
     });
+  }
+
+  /**
+   * Verifies ownership of the current post via a ZK proof.
+   *
+   * @returns A `Promise` that resolves with `true` if the current user is the owner, `false` otherwise.
+   *
+   * @remarks
+   * This method uses selective disclosure — only a boolean result is revealed, not the owner's key.
+   * It will fail if the bulletin board is currently vacant.
+   */
+  async revealOwnership(): Promise<boolean> {
+    this.logger?.info('verifyingOwnership');
+
+    const txData = await this.deployedContract.callTx.revealOwnership();
+
+    this.logger?.trace({
+      transactionAdded: {
+        circuit: 'revealOwnership',
+        txHash: txData.public.txHash,
+        blockHeight: txData.public.blockHeight,
+      },
+    });
+
+    return txData.public.result;
   }
 
   /**

--- a/bboard-cli/src/index.ts
+++ b/bboard-cli/src/index.ts
@@ -130,7 +130,7 @@ const displayLedgerState = async (
     logger.info(`Current state is: '${boardState}'`);
     logger.info(`Current message is: '${latestMessage}'`);
     logger.info(`Current sequence is: ${ledgerState.sequence}`);
-    logger.info(`Current owner is: '${toHex(ledgerState.owner)}'`);
+    logger.info(`Current owner is: '<sealed>'`);
   }
 };
 
@@ -163,7 +163,7 @@ const displayDerivedState = (ledgerState: BBoardDerivedState | undefined, logger
     logger.info(`Current state is: '${boardState}'`);
     logger.info(`Current message is: '${latestMessage}'`);
     logger.info(`Current sequence is: ${ledgerState.sequence}`);
-    logger.info(`Current owner is: '${ledgerState.isOwner ? 'you' : 'not you'}'`);
+    logger.info(`Current owner is: '<sealed>' (use option 7 to verify ownership via ZK proof)`);
   }
 };
 
@@ -181,6 +181,7 @@ You can do one of the following:
   4. Display the current private state (known only to this DApp instance)
   5. Display the current derived state (known only to this DApp instance)
   6. Exit
+  7. Verify ownership (ZK proof)
 Which would you like to do? `;
 
 const mainLoop = async (providers: BBoardProviders, rli: Interface, logger: Logger): Promise<void> => {
@@ -217,6 +218,14 @@ const mainLoop = async (providers: BBoardProviders, rli: Interface, logger: Logg
         case '6':
           logger.info('Exiting...');
           return;
+        case '7':
+          try {
+            const isOwner = await bboardApi.revealOwnership();
+            logger.info(`Ownership verification: ${isOwner ? 'You ARE the owner' : 'You are NOT the owner'}`);
+          } catch (e) {
+            logger.error(`Ownership verification failed: ${e instanceof Error ? e.message : 'unknown error'}`);
+          }
+          break;
         default:
           logger.error(`Invalid choice: ${choice}`);
       }
@@ -312,7 +321,7 @@ export const run = async (config: Config, testEnv: TestEnvironment, logger: Logg
       }
     }
 
-    const zkConfigProvider = new NodeZkConfigProvider<'post' | 'takeDown'>(config.zkConfigPath);
+    const zkConfigProvider = new NodeZkConfigProvider<'post' | 'takeDown' | 'revealOwnership'>(config.zkConfigPath);
     const providers: BBoardProviders = {
       privateStateProvider: levelPrivateStateProvider<PrivateStateId, BBoardPrivateState>({
         privateStateStoreName: config.privateStateStoreName,

--- a/contract/src/bboard.compact
+++ b/contract/src/bboard.compact
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pragma language_version 0.20;
+pragma language_version 0.21;
 
 import CompactStandardLibrary;
 
@@ -28,7 +28,7 @@ export ledger message: Maybe<Opaque<"string">>;
 
 export ledger sequence: Counter;
 
-export ledger owner: Bytes<32>;
+ledger owner: Bytes<32>;
 
 constructor() {
   state = State.VACANT;
@@ -53,6 +53,11 @@ export circuit takeDown(): Opaque<"string"> {
   sequence.increment(1);
   message = none<Opaque<"string">>();
   return formerMsg;
+}
+
+export circuit revealOwnership(): Boolean {
+  assert(state == State.OCCUPIED, "No post to verify ownership of");
+  return disclose(owner == publicKey(localSecretKey(), sequence as Field as Bytes<32>));
 }
 
 export circuit publicKey(sk: Bytes<32>, sequence: Bytes<32>): Bytes<32> {

--- a/contract/src/test/bboard-simulator.ts
+++ b/contract/src/test/bboard-simulator.ts
@@ -17,7 +17,6 @@ import {
   type CircuitContext,
   QueryContext,
   sampleContractAddress,
-  convertFieldToBytes,
   createConstructorContext,
   CostModel,
 } from "@midnight-ntwrk/compact-runtime";
@@ -90,16 +89,11 @@ export class BBoardSimulator {
     return ledger(this.circuitContext.currentQueryContext.state);
   }
 
-  public publicKey(): Uint8Array {
-    const sequence = convertFieldToBytes(
-      32,
-      this.getLedger().sequence,
-      "bboard-simulator.ts",
-    );
-    return this.contract.circuits.publicKey(
+  public revealOwnership(): boolean {
+    const result = this.contract.impureCircuits.revealOwnership(
       this.circuitContext,
-      this.getPrivateState().secretKey,
-      sequence,
-    ).result;
+    );
+    this.circuitContext = result.context;
+    return result.result;
   }
 }

--- a/contract/src/test/bboard.test.ts
+++ b/contract/src/test/bboard.test.ts
@@ -39,7 +39,6 @@ describe("BBoard smart contract", () => {
     expect(initialLedgerState.sequence).toEqual(1n);
     expect(initialLedgerState.message.is_some).toEqual(false);
     expect(initialLedgerState.message.value).toEqual("");
-    expect(initialLedgerState.owner).toEqual(new Uint8Array(32));
     expect(initialLedgerState.state).toEqual(State.VACANT);
     const initialPrivateState = simulator.getPrivateState();
     expect(initialPrivateState).toEqual({ secretKey: key });
@@ -58,14 +57,14 @@ describe("BBoard smart contract", () => {
     expect(ledgerState.sequence).toEqual(1n);
     expect(ledgerState.message.is_some).toEqual(true);
     expect(ledgerState.message.value).toEqual(message);
-    expect(ledgerState.owner).toEqual(simulator.publicKey());
     expect(ledgerState.state).toEqual(State.OCCUPIED);
+    // Verify ownership via ZK proof
+    expect(simulator.revealOwnership()).toEqual(true);
   });
 
   it("lets you take down a message", () => {
     const simulator = new BBoardSimulator(randomBytes(32));
     const initialPrivateState = simulator.getPrivateState();
-    const initialPublicKey = simulator.publicKey();
     const message =
       "Prince Raoden of Arelon awoke early that morning, completely unaware that he had been damned for all eternity.";
     simulator.post(message);
@@ -77,8 +76,6 @@ describe("BBoard smart contract", () => {
     expect(ledgerState.sequence).toEqual(2n);
     expect(ledgerState.message.is_some).toEqual(false);
     expect(ledgerState.message.value).toEqual("");
-    // Technically the circuit doesn't clear the previous owner
-    expect(ledgerState.owner).toEqual(initialPublicKey);
     expect(ledgerState.state).toEqual(State.VACANT);
   });
 
@@ -96,8 +93,9 @@ describe("BBoard smart contract", () => {
     expect(ledgerState.sequence).toEqual(2n);
     expect(ledgerState.message.is_some).toEqual(true);
     expect(ledgerState.message.value).toEqual(message);
-    expect(ledgerState.owner).toEqual(simulator.publicKey());
     expect(ledgerState.state).toEqual(State.OCCUPIED);
+    // Verify ownership via ZK proof
+    expect(simulator.revealOwnership()).toEqual(true);
   });
 
   it("lets a different user post a message after taking down the first", () => {
@@ -111,8 +109,9 @@ describe("BBoard smart contract", () => {
     expect(ledgerState.sequence).toEqual(2n);
     expect(ledgerState.message.is_some).toEqual(true);
     expect(ledgerState.message.value).toEqual(message);
-    expect(ledgerState.owner).toEqual(simulator.publicKey());
     expect(ledgerState.state).toEqual(State.OCCUPIED);
+    // Verify new user is the owner via ZK proof
+    expect(simulator.revealOwnership()).toEqual(true);
   });
 
   it("doesn't let the same user post twice", () => {
@@ -145,5 +144,40 @@ describe("BBoard smart contract", () => {
     expect(() => simulator.takeDown()).toThrow(
       "failed assert: Attempted to take down post, but not the current owner",
     );
+  });
+
+  it("revealOwnership returns true for owner", () => {
+    const simulator = new BBoardSimulator(randomBytes(32));
+    simulator.post("The most important step a man can take is the next one.");
+    expect(simulator.revealOwnership()).toEqual(true);
+  });
+
+  it("revealOwnership returns false for non-owner", () => {
+    const simulator = new BBoardSimulator(randomBytes(32));
+    simulator.post("I will protect those who cannot protect themselves.");
+    simulator.switchUser(randomBytes(32));
+    expect(simulator.revealOwnership()).toEqual(false);
+  });
+
+  it("revealOwnership fails on empty board", () => {
+    const simulator = new BBoardSimulator(randomBytes(32));
+    expect(() => simulator.revealOwnership()).toThrow(
+      "failed assert: No post to verify ownership of",
+    );
+  });
+
+  it("owner field not visible in ledger state", () => {
+    const simulator = new BBoardSimulator(randomBytes(32));
+    const ledgerState = simulator.getLedger();
+    expect("owner" in ledgerState).toEqual(false);
+  });
+
+  it("sealed owner doesn't prevent takeDown by owner", () => {
+    const simulator = new BBoardSimulator(randomBytes(32));
+    simulator.post("Journey before destination.");
+    expect(simulator.revealOwnership()).toEqual(true);
+    simulator.takeDown();
+    const ledgerState = simulator.getLedger();
+    expect(ledgerState.state).toEqual(State.VACANT);
   });
 });


### PR DESCRIPTION
Hide owner field from public Ledger type by removing `export`, add revealOwnership circuit for ZK-based boolean-only ownership proof. Includes full test suite (14 tests), API/CLI updates, and technical write-up covering GDPR Art. 25, Compact semantics (sealed vs non-exported), and privacy trade-offs.