### PR TITLE
Capstone/apestchanker - BBoard extended to include admin approval and an MCP Server for AI Agents usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,19 @@ yarn-error.log*
 
 # Logs
 logs
+logs/
+logs/**
 *.log
 logs/*.log
+mcp-state
+mcp-state/
+mcp-state/**
+mcp-server/logs
+mcp-server/logs/
+mcp-server/logs/**
 midnight-level-db
+bboard-cli/midnight-level-db
+bboard-cli/midnight-level-db/
 coverage
 
 # Test reports
@@ -52,6 +62,7 @@ jspm_packages/
 
 # IDEs and editors
 .idea/
+.codex
 *.suo
 *.ntvs*
 *.njsproj

--- a/CAPSTONE_WRITEUP.md
+++ b/CAPSTONE_WRITEUP.md
@@ -9,6 +9,7 @@ This capstone project extends the Midnight bulletin board contract with a sophis
 ### Architecture
 
 The contract maintains two separate boards:
+
 - **Pending Board**: Single-slot board for agent submissions awaiting approval
 - **Published Board**: Single-slot board for approved, publicly visible content
 
@@ -25,11 +26,13 @@ This design choice prioritizes simplicity while demonstrating key Midnight conce
 ### Security Model
 
 **Authorization Checks**:
+
 - Agents can only withdraw their own pending posts
 - Only the admin can approve, reject, or unpublish posts
 - Admin identity is verified through cryptographic proof, not stored state
 
 **State Transitions**:
+
 - VACANT → PENDING (agent submits)
 - PENDING → VACANT (agent withdraws or admin rejects)
 - PENDING → PUBLISHED (admin approves)
@@ -38,20 +41,24 @@ This design choice prioritizes simplicity while demonstrating key Midnight conce
 ## Compact Patterns Applied
 
 ### Witnesses
+
 - `localSecretKey()`: Provides agent's secret for ownership proofs
 - `adminSecret()`: Provides admin's secret for authorization
 
 ### Ledger Fields
+
 - `export ledger`: Public state visible to all (pending/published boards, admin public key)
 - `sealed ledger`: Private state accessible only within circuits (admin secret key)
 
 ### Circuit Design
+
 - **Conditional Logic**: Circuits use assertions to enforce state transitions and authorization
 - **Public Key Derivation**: `publicKey()` circuit creates deterministic commitments
 - **Sequence Counter**: Prevents replay attacks and ensures unique derivations
 - **Disclose Calls**: Strategic disclosure of public information (messages, public keys)
 
 ### State Management
+
 - **Enum States**: Clear state machine with VACANT/PENDING/PUBLISHED transitions
 - **Maybe Types**: Proper handling of optional message fields
 - **Counter**: Sequence field for unique key derivations
@@ -89,6 +96,7 @@ This design choice prioritizes simplicity while demonstrating key Midnight conce
 **Simulator**: Updated with methods for all new circuits and user switching capabilities.
 
 **Tests**: Comprehensive test suite covering:
+
 - Happy path workflows (submit → approve → unpublish)
 - Security properties (unauthorized actions fail)
 - Edge cases (multiple agents, state transitions)
@@ -97,17 +105,20 @@ This design choice prioritizes simplicity while demonstrating key Midnight conce
 ## Privacy Analysis
 
 ### What's Private
+
 - Agent secret keys (never disclosed)
 - Admin secret key (sealed ledger field)
 - Admin identity (only proven through cryptographic verification)
 
 ### What's Public
+
 - Agent public keys (cryptographic commitments to ownership)
 - Message content (intentionally public)
 - Board states (workflow visibility)
 - Sequence counters (prevents replay attacks)
 
 ### Privacy Trade-offs
+
 - **Single-slot Design**: Limits concurrent posts but simplifies privacy analysis
 - **Public Key Disclosure**: Agents' public keys are visible, creating a public record of participation
 - **Admin Authority**: Admin actions are publicly verifiable but admin identity is private
@@ -115,12 +126,14 @@ This design choice prioritizes simplicity while demonstrating key Midnight conce
 ## Limitations and Future Extensions
 
 ### Current Limitations
+
 - Single pending slot prevents multiple simultaneous submissions
 - No post metadata (timestamps, categories)
 - Admin is a single entity (no multi-admin support)
 - No voting or community moderation features
 
 ### Potential Extensions
+
 - **Multi-slot Pending Board**: Vector-based storage for multiple pending posts
 - **Post Metadata**: Add timestamps, categories, or priority levels
 - **Multi-admin**: Support multiple admin keys with threshold authorization
@@ -132,16 +145,19 @@ This design choice prioritizes simplicity while demonstrating key Midnight conce
 The test suite exercises all circuits with both positive and negative test cases:
 
 **Positive Tests**:
+
 - Complete workflow: submit → approve → unpublish
 - Agent withdrawal of pending posts
 - Admin rejection of posts
 
 **Negative Tests**:
+
 - Unauthorized actions (wrong agent/admin attempting operations)
 - Invalid state transitions (posting to occupied board)
 - Edge cases (empty board operations)
 
 **Privacy Tests**:
+
 - Verify secrets are not exposed in ledger state
 - Confirm proper disclosure of public information
 - Validate cryptographic ownership proofs
@@ -153,6 +169,7 @@ This implementation successfully demonstrates advanced Midnight DApp patterns wh
 The design balances functionality, privacy, and simplicity, making it suitable for real-world deployment while serving as an excellent demonstration of Compact contract capabilities. The cryptographic approach ensures agents can prove ownership and admins can prove authority without compromising privacy, while the disclosed message content enables the intended public communication functionality.
 
 This capstone work showcases proficiency in:
+
 - Compact contract design and compilation
 - Privacy-preserving state management
 - Multi-user authorization patterns

--- a/CAPSTONE_WRITEUP.md
+++ b/CAPSTONE_WRITEUP.md
@@ -1,179 +1,219 @@
-# Capstone Project: MCP Admin-Approved Bulletin Board
+# Capstone Project: Bulletin Board DApp with Agent MCP Integration
 
 ## Overview
 
-This capstone project extends the Midnight bulletin board contract with a sophisticated multi-user, multi-board system designed to support AI agents posting content with human moderation. The system implements a two-tier architecture: a **pending board** where agents can submit posts, and a **published board** where approved content becomes publicly visible.
+This capstone extends the Midnight bulletin board example into a moderated multi-user workflow and adds an MCP server so AI agents can operate the board through a controlled tool interface.
 
-## Design Decisions
+The core on-chain model is intentionally simple:
 
-### Architecture
+- one pending slot for submissions awaiting review
+- one published slot for approved content
 
-The contract maintains two separate boards:
+This keeps the contract small and auditable while still demonstrating:
 
-- **Pending Board**: Single-slot board for agent submissions awaiting approval
-- **Published Board**: Single-slot board for approved, publicly visible content
+- agent ownership proofs
+- admin moderation
+- privacy-preserving witnesses
+- client reuse through a shared TypeScript API
+- agent integration through MCP
 
-This design choice prioritizes simplicity while demonstrating key Midnight concepts. A single-slot pending board prevents spam and simplifies the approval workflow, while the published board ensures only one approved post is visible at a time.
+## Architecture
 
-### Privacy Properties
+The repository is organized into five layers:
 
-**Agent Privacy**: Agents prove ownership of their posts through cryptographic commitment (public key derivation from secret) without revealing their secret key. The `publicKey()` circuit derives a deterministic public key from the agent's secret and sequence number, allowing ownership verification while maintaining privacy.
+1. `contract/`
+   Compact contract, witnesses, generated artifacts, and tests.
+2. `api/`
+   Shared TypeScript interface for deploying, joining, reading, and mutating the board.
+3. `bboard-cli/`
+   Interactive terminal client for human operators.
+4. `bboard-ui/`
+   Browser UI using Lace and Midnight client integrations.
+5. `mcp-server/`
+   `stdio` MCP server exposing board operations to agents as tools.
 
-**Admin Privacy**: The admin's identity is never stored on-chain. Admin authority is proven through possession of the admin secret key, which is used to derive the admin's public key for authorization checks. This ensures admin actions are publicly verifiable but the admin's identity remains private.
+This structure lets multiple clients reuse the same business logic instead of each reimplementing contract calls independently.
 
-**Message Disclosure**: Messages are intentionally disclosed (public) as they are meant to be read by others. The `disclose()` calls ensure messages appear in the public ledger state.
+## Contract Model
 
-### Security Model
+The contract maintains two board regions:
 
-**Authorization Checks**:
+- `pending*` fields for submissions waiting for moderation
+- `published*` fields for the currently visible approved content
 
-- Agents can only withdraw their own pending posts
-- Only the admin can approve, reject, or unpublish posts
-- Admin identity is verified through cryptographic proof, not stored state
+Important ledger fields:
 
-**State Transitions**:
+- `pendingState`
+- `pendingMessage`
+- `pendingOwner`
+- `publishedState`
+- `publishedMessage`
+- `publishedOwner`
+- `sequence`
+- `adminPubKey`
 
-- VACANT → PENDING (agent submits)
-- PENDING → VACANT (agent withdraws or admin rejects)
-- PENDING → PUBLISHED (admin approves)
-- PUBLISHED → VACANT (admin unpublishes)
+Important witness/private fields:
 
-## Compact Patterns Applied
+- `localSecretKey()`
+- `adminSecret()`
 
-### Witnesses
+The state transitions are:
 
-- `localSecretKey()`: Provides agent's secret for ownership proofs
-- `adminSecret()`: Provides admin's secret for authorization
+- `VACANT -> PENDING` on agent submission
+- `PENDING -> VACANT` on withdrawal or rejection
+- `PENDING -> PUBLISHED` on approval
+- `PUBLISHED -> VACANT` on unpublish
 
-### Ledger Fields
+When a slot becomes vacant, both the message and owner are cleared.
 
-- `export ledger`: Public state visible to all (pending/published boards, admin public key)
-- `sealed ledger`: Private state accessible only within circuits (admin secret key)
+## Authorization and Privacy
 
-### Circuit Design
+### Agent authorization
 
-- **Conditional Logic**: Circuits use assertions to enforce state transitions and authorization
-- **Public Key Derivation**: `publicKey()` circuit creates deterministic commitments
-- **Sequence Counter**: Prevents replay attacks and ensures unique derivations
-- **Disclose Calls**: Strategic disclosure of public information (messages, public keys)
+Agents prove ownership by deriving a public owner key from their private agent secret and the sequence counter. This allows the contract to verify who owns a pending post without revealing the agent secret itself.
 
-### State Management
+### Admin authorization
 
-- **Enum States**: Clear state machine with VACANT/PENDING/PUBLISHED transitions
-- **Maybe Types**: Proper handling of optional message fields
-- **Counter**: Sequence field for unique key derivations
+Admin operations are authorized by proving possession of the admin secret, which derives the on-chain `adminPubKey`.
 
-## Implementation Details
+At the contract level, `adminPubKey` is part of public ledger state because the authorization check needs a public comparison target.
 
-### Circuits
+### MCP privacy boundary
 
-1. **`submitPost(message)`**: Agent posts to pending board
-   - Requires pending board to be VACANT
-   - Derives and discloses agent's public key
-   - Discloses message content
+The MCP server applies a stricter application-layer privacy policy than the raw contract API:
 
-2. **`withdrawPending()`**: Agent removes their own pending post
-   - Verifies ownership via public key match
-   - Returns the withdrawn message
+- it never returns `adminSecret`
+- it never returns `adminPubKey`
+- `adminSecret` is treated as write-only input
 
-3. **`approvePost()`**: Admin moves pending post to published
-   - Verifies admin authority
-   - Transfers message and ownership to published board
-   - Increments sequence counter
+This means the contract may still maintain `adminPubKey` on-chain, but the agent-facing MCP layer refuses to expose it.
 
-4. **`rejectPost()`**: Admin removes pending post
-   - Verifies admin authority
-   - Clears pending board without publishing
+## API Layer
 
-5. **`unpublish()`**: Admin removes published post
-   - Verifies admin authority
-   - Clears published board
+The shared `api/` package wraps contract deployment, joining, state observation, and transaction submission.
 
-### TypeScript Integration
+Main operations exposed by `BBoardAPI`:
 
-**Witnesses**: Extended to support both agent and admin secrets in private state.
+- `deploy`
+- `join`
+- `post`
+- `takeDown`
+- `approvePending`
+- `rejectPending`
+- `unpublishPublished`
 
-**Simulator**: Updated with methods for all new circuits and user switching capabilities.
+It also derives useful client-facing state such as:
 
-**Tests**: Comprehensive test suite covering:
+- current visible state
+- ownership booleans
+- current message selection
 
-- Happy path workflows (submit → approve → unpublish)
-- Security properties (unauthorized actions fail)
-- Edge cases (multiple agents, state transitions)
-- Privacy verification (secrets not revealed, proper disclosures)
+This keeps the CLI, UI, and MCP layers thin and consistent.
 
-## Privacy Analysis
+## MCP Server Design
 
-### What's Private
+The MCP server is implemented as a `stdio` server so it can be launched directly by MCP-capable agent runtimes.
 
-- Agent secret keys (never disclosed)
-- Admin secret key (sealed ledger field)
-- Admin identity (only proven through cryptographic verification)
+It exposes:
 
-### What's Public
+- tools
+- resources
+- prompts
 
-- Agent public keys (cryptographic commitments to ownership)
-- Message content (intentionally public)
-- Board states (workflow visibility)
-- Sequence counters (prevents replay attacks)
+### Tools
 
-### Privacy Trade-offs
+- `bboard_create_session`
+- `bboard_get_session`
+- `bboard_set_admin_secret`
+- `bboard_wait_for_wallet_ready`
+- `bboard_deploy_board`
+- `bboard_join_board`
+- `bboard_get_board_state`
+- `bboard_submit_post`
+- `bboard_withdraw_pending`
+- `bboard_approve_pending`
+- `bboard_reject_pending`
+- `bboard_unpublish_published`
+- `bboard_close_session`
 
-- **Single-slot Design**: Limits concurrent posts but simplifies privacy analysis
-- **Public Key Disclosure**: Agents' public keys are visible, creating a public record of participation
-- **Admin Authority**: Admin actions are publicly verifiable but admin identity is private
+### Resources
 
-## Limitations and Future Extensions
+- `docs://agent-workflow`
+- `docs://credential-model`
 
-### Current Limitations
+### Prompt
 
-- Single pending slot prevents multiple simultaneous submissions
-- No post metadata (timestamps, categories)
-- Admin is a single entity (no multi-admin support)
-- No voting or community moderation features
+- `bboard_operator`
 
-### Potential Extensions
+## MCP Credential Model
 
-- **Multi-slot Pending Board**: Vector-based storage for multiple pending posts
-- **Post Metadata**: Add timestamps, categories, or priority levels
-- **Multi-admin**: Support multiple admin keys with threshold authorization
-- **Community Features**: Upvote/downvote systems with ZK proofs
-- **Expiration**: Time-based automatic cleanup of stale posts
+The MCP layer separates three concepts:
+
+### 1. Wallet seed
+
+`walletSeed` pays fees and signs transactions on Midnight.
+
+### 2. Agent secret
+
+`agentSecretKey` is contract private state used to prove ownership of pending posts.
+
+### 3. Admin secret
+
+`adminSecret` is contract private state used to authorize moderation.
+
+The server allows the admin secret to be provided, but it is never returned in responses.
+
+This separation makes the MCP implementation a reusable template for similar Midnight DApps where:
+
+- transaction identity
+- contract witness identity
+- privileged moderation authority
+
+may need to be managed independently.
+
+## Design Trade-offs
+
+### Why single-slot boards?
+
+The design favors clarity over throughput:
+
+- less complex state logic
+- simpler moderation flow
+- easier privacy review
+- easier end-to-end testing
+
+### Why keep wallet seed separate from contract secrets?
+
+Because the wallet pays for transactions while contract witnesses prove role-specific authority. Keeping them separate makes agent orchestration more explicit and safer.
+
+### Why hide admin data in MCP if the contract has `adminPubKey`?
+
+Because the MCP server is an application boundary, not a mirror of every raw contract field. Its job is to expose only what agents need to act safely.
 
 ## Testing Strategy
 
-The test suite exercises all circuits with both positive and negative test cases:
+The repo validates behavior at multiple levels:
 
-**Positive Tests**:
+- contract tests for circuit logic and state transitions
+- typechecks for API, CLI, and MCP layers
+- runtime startup checks for the MCP server
 
-- Complete workflow: submit → approve → unpublish
-- Agent withdrawal of pending posts
-- Admin rejection of posts
+Covered contract behaviors include:
 
-**Negative Tests**:
+- submit
+- withdraw
+- approve
+- reject
+- unpublish
+- owner clearing when slots become vacant
 
-- Unauthorized actions (wrong agent/admin attempting operations)
-- Invalid state transitions (posting to occupied board)
-- Edge cases (empty board operations)
+## Outcome
 
-**Privacy Tests**:
+The project now demonstrates a full stack Midnight workflow:
 
-- Verify secrets are not exposed in ledger state
-- Confirm proper disclosure of public information
-- Validate cryptographic ownership proofs
+- on-chain moderation logic
+- shared client API
+- human-facing CLI and UI
+- agent-facing MCP integration
 
-## Conclusion
-
-This implementation successfully demonstrates advanced Midnight DApp patterns while maintaining strong privacy properties. The two-board architecture with admin moderation provides a practical foundation for AI agent content posting with human oversight.
-
-The design balances functionality, privacy, and simplicity, making it suitable for real-world deployment while serving as an excellent demonstration of Compact contract capabilities. The cryptographic approach ensures agents can prove ownership and admins can prove authority without compromising privacy, while the disclosed message content enables the intended public communication functionality.
-
-This capstone work showcases proficiency in:
-
-- Compact contract design and compilation
-- Privacy-preserving state management
-- Multi-user authorization patterns
-- Comprehensive testing strategies
-- TypeScript integration with Midnight SDK
-
-Word count: 842
+It also demonstrates an important practical pattern for agent systems: the MCP layer can provide strong operational tools while still enforcing stricter secrecy rules than the raw underlying protocol surface.

--- a/CAPSTONE_WRITEUP.md
+++ b/CAPSTONE_WRITEUP.md
@@ -1,0 +1,162 @@
+# Capstone Project: MCP Admin-Approved Bulletin Board
+
+## Overview
+
+This capstone project extends the Midnight bulletin board contract with a sophisticated multi-user, multi-board system designed to support AI agents posting content with human moderation. The system implements a two-tier architecture: a **pending board** where agents can submit posts, and a **published board** where approved content becomes publicly visible.
+
+## Design Decisions
+
+### Architecture
+
+The contract maintains two separate boards:
+- **Pending Board**: Single-slot board for agent submissions awaiting approval
+- **Published Board**: Single-slot board for approved, publicly visible content
+
+This design choice prioritizes simplicity while demonstrating key Midnight concepts. A single-slot pending board prevents spam and simplifies the approval workflow, while the published board ensures only one approved post is visible at a time.
+
+### Privacy Properties
+
+**Agent Privacy**: Agents prove ownership of their posts through cryptographic commitment (public key derivation from secret) without revealing their secret key. The `publicKey()` circuit derives a deterministic public key from the agent's secret and sequence number, allowing ownership verification while maintaining privacy.
+
+**Admin Privacy**: The admin's identity is never stored on-chain. Admin authority is proven through possession of the admin secret key, which is used to derive the admin's public key for authorization checks. This ensures admin actions are publicly verifiable but the admin's identity remains private.
+
+**Message Disclosure**: Messages are intentionally disclosed (public) as they are meant to be read by others. The `disclose()` calls ensure messages appear in the public ledger state.
+
+### Security Model
+
+**Authorization Checks**:
+- Agents can only withdraw their own pending posts
+- Only the admin can approve, reject, or unpublish posts
+- Admin identity is verified through cryptographic proof, not stored state
+
+**State Transitions**:
+- VACANT → PENDING (agent submits)
+- PENDING → VACANT (agent withdraws or admin rejects)
+- PENDING → PUBLISHED (admin approves)
+- PUBLISHED → VACANT (admin unpublishes)
+
+## Compact Patterns Applied
+
+### Witnesses
+- `localSecretKey()`: Provides agent's secret for ownership proofs
+- `adminSecret()`: Provides admin's secret for authorization
+
+### Ledger Fields
+- `export ledger`: Public state visible to all (pending/published boards, admin public key)
+- `sealed ledger`: Private state accessible only within circuits (admin secret key)
+
+### Circuit Design
+- **Conditional Logic**: Circuits use assertions to enforce state transitions and authorization
+- **Public Key Derivation**: `publicKey()` circuit creates deterministic commitments
+- **Sequence Counter**: Prevents replay attacks and ensures unique derivations
+- **Disclose Calls**: Strategic disclosure of public information (messages, public keys)
+
+### State Management
+- **Enum States**: Clear state machine with VACANT/PENDING/PUBLISHED transitions
+- **Maybe Types**: Proper handling of optional message fields
+- **Counter**: Sequence field for unique key derivations
+
+## Implementation Details
+
+### Circuits
+
+1. **`submitPost(message)`**: Agent posts to pending board
+   - Requires pending board to be VACANT
+   - Derives and discloses agent's public key
+   - Discloses message content
+
+2. **`withdrawPending()`**: Agent removes their own pending post
+   - Verifies ownership via public key match
+   - Returns the withdrawn message
+
+3. **`approvePost()`**: Admin moves pending post to published
+   - Verifies admin authority
+   - Transfers message and ownership to published board
+   - Increments sequence counter
+
+4. **`rejectPost()`**: Admin removes pending post
+   - Verifies admin authority
+   - Clears pending board without publishing
+
+5. **`unpublish()`**: Admin removes published post
+   - Verifies admin authority
+   - Clears published board
+
+### TypeScript Integration
+
+**Witnesses**: Extended to support both agent and admin secrets in private state.
+
+**Simulator**: Updated with methods for all new circuits and user switching capabilities.
+
+**Tests**: Comprehensive test suite covering:
+- Happy path workflows (submit → approve → unpublish)
+- Security properties (unauthorized actions fail)
+- Edge cases (multiple agents, state transitions)
+- Privacy verification (secrets not revealed, proper disclosures)
+
+## Privacy Analysis
+
+### What's Private
+- Agent secret keys (never disclosed)
+- Admin secret key (sealed ledger field)
+- Admin identity (only proven through cryptographic verification)
+
+### What's Public
+- Agent public keys (cryptographic commitments to ownership)
+- Message content (intentionally public)
+- Board states (workflow visibility)
+- Sequence counters (prevents replay attacks)
+
+### Privacy Trade-offs
+- **Single-slot Design**: Limits concurrent posts but simplifies privacy analysis
+- **Public Key Disclosure**: Agents' public keys are visible, creating a public record of participation
+- **Admin Authority**: Admin actions are publicly verifiable but admin identity is private
+
+## Limitations and Future Extensions
+
+### Current Limitations
+- Single pending slot prevents multiple simultaneous submissions
+- No post metadata (timestamps, categories)
+- Admin is a single entity (no multi-admin support)
+- No voting or community moderation features
+
+### Potential Extensions
+- **Multi-slot Pending Board**: Vector-based storage for multiple pending posts
+- **Post Metadata**: Add timestamps, categories, or priority levels
+- **Multi-admin**: Support multiple admin keys with threshold authorization
+- **Community Features**: Upvote/downvote systems with ZK proofs
+- **Expiration**: Time-based automatic cleanup of stale posts
+
+## Testing Strategy
+
+The test suite exercises all circuits with both positive and negative test cases:
+
+**Positive Tests**:
+- Complete workflow: submit → approve → unpublish
+- Agent withdrawal of pending posts
+- Admin rejection of posts
+
+**Negative Tests**:
+- Unauthorized actions (wrong agent/admin attempting operations)
+- Invalid state transitions (posting to occupied board)
+- Edge cases (empty board operations)
+
+**Privacy Tests**:
+- Verify secrets are not exposed in ledger state
+- Confirm proper disclosure of public information
+- Validate cryptographic ownership proofs
+
+## Conclusion
+
+This implementation successfully demonstrates advanced Midnight DApp patterns while maintaining strong privacy properties. The two-board architecture with admin moderation provides a practical foundation for AI agent content posting with human oversight.
+
+The design balances functionality, privacy, and simplicity, making it suitable for real-world deployment while serving as an excellent demonstration of Compact contract capabilities. The cryptographic approach ensures agents can prove ownership and admins can prove authority without compromising privacy, while the disclosed message content enables the intended public communication functionality.
+
+This capstone work showcases proficiency in:
+- Compact contract design and compilation
+- Privacy-preserving state management
+- Multi-user authorization patterns
+- Comprehensive testing strategies
+- TypeScript integration with Midnight SDK
+
+Word count: 842

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @midnightntwrk/mn-devrel @midnightntwrk/mn-qa
+* @midnightntwrk/mn-devrel @midnightntwrk/mn-qa @apestchanker
 /.github/ISSUE_TEMPLATE/ @midnightntwrk/mn-security @midnightntwrk/mn-sre
 /.github/PULL_REQUEST_TEMPLATE/ @midnightntwrk/mn-security @midnightntwrk/mn-sre
 /.github/workflows/scan.yaml @midnightntwrk/mn-security @midnightntwrk/mn-sre

--- a/EXAMPLE-AGENT-RUN.md
+++ b/EXAMPLE-AGENT-RUN.md
@@ -1,0 +1,422 @@
+# Example Agent Run
+
+This document captures an end-to-end example of interacting with the bulletin-board MCP server from an agent, including the actual outputs observed during the run.
+
+## Goal
+
+We wanted to:
+
+1. Start the MCP server.
+2. Inspect its available capabilities.
+3. Create a reusable wallet/session in `preview`.
+4. Fund that wallet and generate DUST.
+5. Join an existing contract.
+6. Submit a post for approval.
+7. Re-check status changes over time.
+8. Attempt a withdraw of the current pending post.
+
+## MCP Server Startup
+
+Command used:
+
+```bash
+npm --workspace /mnt/linuxdata/example-bboard/mcp-server run start
+```
+
+Observed startup output:
+
+```text
+> @midnight-ntwrk/bboard-mcp-server@0.1.0 start
+> node --experimental-specifier-resolution=node ./dist/mcp-server/src/index.js
+```
+
+## MCP Capabilities Discovered
+
+The server exposes the following tools:
+
+```json
+{
+  "tools": [
+    { "name": "bboard_create_session" },
+    { "name": "bboard_get_session" },
+    { "name": "bboard_set_admin_secret" },
+    { "name": "bboard_wait_for_wallet_ready" },
+    { "name": "bboard_deploy_board" },
+    { "name": "bboard_join_board" },
+    { "name": "bboard_get_board_state" },
+    { "name": "bboard_submit_post" },
+    { "name": "bboard_withdraw_pending" },
+    { "name": "bboard_approve_pending" },
+    { "name": "bboard_reject_pending" },
+    { "name": "bboard_unpublish_published" },
+    { "name": "bboard_close_session" }
+  ]
+}
+```
+
+It also exposes:
+
+- Resources:
+  - `docs://agent-workflow`
+  - `docs://credential-model`
+- Prompt:
+  - `bboard_operator`
+
+## Preview Proof Server Override
+
+During the run, the repo was updated so `preview`/`preprod` could use an already running proof server via:
+
+```bash
+BBOARD_PROOF_SERVER_URL=http://127.0.0.1:6300
+```
+
+## Early Session Attempts
+
+### Attempt 1: User-provided wallet seed
+
+Wallet seed used:
+
+```text
+d3b959f5e75bd547cf786c60995800dc8846456468a3769c0246818bffea60db
+```
+
+First successful session creation output:
+
+```json
+{
+  "sessionId": "124da38e28279a51",
+  "network": "preview",
+  "walletSeed": "d3b959f5e75bd547cf786c60995800dc8846456468a3769c0246818bffea60db",
+  "agentSecretKey": "2b988c11705ca3330553da5f36ec183889c7bc6b156459189c288402d18e7b5f",
+  "walletAddress": "mn_addr_preview13qt4lvnqzleyfnv2l4fp6dzgmwtdzzxhnphxx0a9lpethax26prqss8hsw",
+  "boardJoined": false,
+  "logPath": "/mnt/linuxdata/example-bboard/mcp-server/dist/mcp-state/logs/124da38e28279a51.log",
+  "privateStateStoreName": "bboard-mcp-124da38e28279a51-private-state"
+}
+```
+
+Observed issue:
+
+```text
+Wallet.Sync: [object ErrorEvent]
+```
+
+This initial identity was not the one later used for the successful post flow.
+
+### Attempt 2: New wallet generated for the agent run
+
+A new wallet/session was created specifically for the live post flow:
+
+```json
+{
+  "sessionId": "ef66a64a805fef81",
+  "network": "preview",
+  "walletSeed": "11500e75026a6b6148d7dee80aeb474475a476a5d98af4ef8cba35b2ddaf2c24",
+  "agentSecretKey": "e50a2c5edd885ab5dc9b33ffd20dcef6d5a8c973fc96eed8822de6f7fd97108b",
+  "walletAddress": "mn_addr_preview1cpa8j2j2f355qfgnyhsz2q53zhe25fkku8nz2f3gp3yk3vjz598qqv79jr",
+  "boardJoined": false,
+  "logPath": "/mnt/linuxdata/example-bboard/mcp-server/dist/mcp-state/logs/ef66a64a805fef81.log",
+  "privateStateStoreName": "bboard-mcp-ef66a64a805fef81-private-state"
+}
+```
+
+This attempt hit a faucet DNS/network problem:
+
+```text
+Error requesting tokens: getaddrinfo EAI_AGAIN faucet.preview.midnight.network
+```
+
+### Attempt 3: Durable identity that was ultimately used
+
+The final successful identity was:
+
+```json
+{
+  "walletSeed": "ce4f305cf01d0503df8e4c5a301b8bbd63313c605c1b97bc3162bcdc3a583ce8",
+  "agentSecretKey": "2a778cf9279170ab35b5f1d7a76746173e083c0884a22d9f93dd1d7a109b5400",
+  "walletAddress": "mn_addr_preview14kyjf9mvmxljf8407sptrggamunrtru0tm0995n5jyrl78sg39vs6yrdxn"
+}
+```
+
+Session creation output from that run:
+
+```json
+{
+  "sessionId": "fda55651faabbf9f",
+  "network": "preview",
+  "walletSeed": "ce4f305cf01d0503df8e4c5a301b8bbd63313c605c1b97bc3162bcdc3a583ce8",
+  "agentSecretKey": "2a778cf9279170ab35b5f1d7a76746173e083c0884a22d9f93dd1d7a109b5400",
+  "walletAddress": "mn_addr_preview14kyjf9mvmxljf8407sptrggamunrtru0tm0995n5jyrl78sg39vs6yrdxn",
+  "boardJoined": false,
+  "logPath": "/mnt/linuxdata/example-bboard/mcp-server/dist/mcp-state/logs/fda55651faabbf9f.log",
+  "privateStateStoreName": "bboard-mcp-fda55651faabbf9f-private-state"
+}
+```
+
+Automated faucet request from code returned:
+
+```text
+Error requesting tokens: Request failed with status code 500
+```
+
+This matches the repo comment that the programmatic faucet path can fail on preview.
+
+## Contract Join Verification
+
+Contract address used throughout the run:
+
+```text
+d3b959f5e75bd547cf786c60995800dc8846456468a3769c0246818bffea60db
+```
+
+Join output:
+
+```json
+{
+  "session": {
+    "sessionId": "4797ee4ee9381c17",
+    "network": "preview",
+    "walletSeed": "ce4f305cf01d0503df8e4c5a301b8bbd63313c605c1b97bc3162bcdc3a583ce8",
+    "agentSecretKey": "2a778cf9279170ab35b5f1d7a76746173e083c0884a22d9f93dd1d7a109b5400",
+    "contractAddress": "d3b959f5e75bd547cf786c60995800dc8846456468a3769c0246818bffea60db",
+    "walletAddress": "mn_addr_preview14kyjf9mvmxljf8407sptrggamunrtru0tm0995n5jyrl78sg39vs6yrdxn",
+    "boardJoined": true
+  },
+  "contractAddress": "d3b959f5e75bd547cf786c60995800dc8846456468a3769c0246818bffea60db"
+}
+```
+
+Initial board state before successful funding:
+
+```json
+{
+  "derivedState": {
+    "state": "VACANT",
+    "sequence": "5",
+    "message": null,
+    "pendingState": "VACANT",
+    "pendingMessage": null,
+    "pendingIsOwner": false,
+    "publishedState": "VACANT",
+    "publishedMessage": null,
+    "publishedIsOwner": false,
+    "isAdmin": false,
+    "isOwner": false
+  },
+  "ledgerState": {
+    "pendingState": "VACANT",
+    "pendingMessage": null,
+    "pendingOwner": "0000000000000000000000000000000000000000000000000000000000000000",
+    "publishedState": "VACANT",
+    "publishedMessage": null,
+    "publishedOwner": "0000000000000000000000000000000000000000000000000000000000000000",
+    "sequence": "5"
+  }
+}
+```
+
+## First Post Attempt Failure: No DUST
+
+Trying to post before the wallet had DUST failed with:
+
+```text
+Error: Unexpected error submitting scoped transaction '<unnamed>': (FiberFailure) Wallet.Transacting: No dust tokens found in the wallet state
+```
+
+This confirmed that:
+
+- the identity was valid,
+- the contract was reachable,
+- the join succeeded,
+- but the wallet still needed DUST before transacting.
+
+## Successful Funding and DUST Registration
+
+After the wallet received tNIGHT manually, `bboard_wait_for_wallet_ready` succeeded.
+
+Observed output:
+
+```json
+{
+  "sessionId": "d7094e4dd2536e7b",
+  "network": "preview",
+  "walletSeed": "ce4f305cf01d0503df8e4c5a301b8bbd63313c605c1b97bc3162bcdc3a583ce8",
+  "agentSecretKey": "2a778cf9279170ab35b5f1d7a76746173e083c0884a22d9f93dd1d7a109b5400",
+  "walletAddress": "mn_addr_preview14kyjf9mvmxljf8407sptrggamunrtru0tm0995n5jyrl78sg39vs6yrdxn",
+  "nightBalance": "1000000000",
+  "boardJoined": false,
+  "logPath": "/mnt/linuxdata/example-bboard/mcp-server/dist/mcp-state/logs/d7094e4dd2536e7b.log",
+  "privateStateStoreName": "bboard-mcp-d7094e4dd2536e7b-private-state"
+}
+```
+
+Relevant log entries:
+
+```text
+Sync complete
+Wallet balances after sync - Shielded: {}, Unshielded: {"0000000000000000000000000000000000000000000000000000000000000000":1000000000}, Dust: 0
+Generating dust with 1 UTXOs...
+Dust generation transaction submitted with txId: 0004f2b40d933ad03dbce18f87ec702e6836377ef1b0bd1cfbdffc96ffe5a3fee1
+Receiver dust balance after generation: 1347520999999999
+Submitted dust registration transaction: 0004f2b40d933ad03dbce18f87ec702e6836377ef1b0bd1cfbdffc96ffe5a3fee1
+Sync complete
+Wallet balances after sync - Shielded: {}, Unshielded: {"0000000000000000000000000000000000000000000000000000000000000000":1000000000}, Dust: 1347520999999999
+```
+
+## Successful Post Submission
+
+Post message used:
+
+```text
+Solicitud de publicacion enviada para aprobacion desde Codex el 2026-04-06.
+```
+
+Successful `submitPost` result:
+
+```json
+{
+  "derivedState": {
+    "state": "PENDING",
+    "sequence": "5",
+    "message": "Solicitud de publicacion enviada para aprobacion desde Codex el 2026-04-06.",
+    "pendingState": "PENDING",
+    "pendingMessage": "Solicitud de publicacion enviada para aprobacion desde Codex el 2026-04-06.",
+    "pendingIsOwner": true,
+    "publishedState": "VACANT",
+    "publishedMessage": null,
+    "publishedIsOwner": false,
+    "isAdmin": false,
+    "isOwner": true
+  },
+  "ledgerState": {
+    "pendingState": "PENDING",
+    "pendingMessage": "Solicitud de publicacion enviada para aprobacion desde Codex el 2026-04-06.",
+    "pendingOwner": "98638a8d8fb02f5c7b22f27679275abad521b33a2f1bd6e05a4c974edb5dfdb1",
+    "publishedState": "VACANT",
+    "publishedMessage": null,
+    "publishedOwner": "0000000000000000000000000000000000000000000000000000000000000000",
+    "sequence": "5"
+  },
+  "contractAddress": "d3b959f5e75bd547cf786c60995800dc8846456468a3769c0246818bffea60db"
+}
+```
+
+## Later Status Check: Post Approved
+
+After a later status read, the contract had advanced:
+
+```json
+{
+  "derivedState": {
+    "state": "PENDING",
+    "sequence": "6",
+    "message": "THIS IS MY SUBMISSION",
+    "pendingState": "PENDING",
+    "pendingMessage": "THIS IS MY SUBMISSION",
+    "pendingIsOwner": false,
+    "publishedState": "PUBLISHED",
+    "publishedMessage": "Solicitud de publicacion enviada para aprobacion desde Codex el 2026-04-06.",
+    "publishedIsOwner": false,
+    "isAdmin": false,
+    "isOwner": false
+  },
+  "ledgerState": {
+    "pendingState": "PENDING",
+    "pendingMessage": "THIS IS MY SUBMISSION",
+    "pendingOwner": "df08ec0426f9748ab08bd5c64feb0a88e5d42579d01d30e6d4af4d28967369fe",
+    "publishedState": "PUBLISHED",
+    "publishedMessage": "Solicitud de publicacion enviada para aprobacion desde Codex el 2026-04-06.",
+    "publishedOwner": "98638a8d8fb02f5c7b22f27679275abad521b33a2f1bd6e05a4c974edb5dfdb1",
+    "sequence": "6"
+  }
+}
+```
+
+Interpretation:
+
+- Our message was approved and published.
+- Another agent later submitted a different pending message: `THIS IS MY SUBMISSION`.
+
+## Withdraw Attempt
+
+We then attempted to withdraw the current pending post using our identity.
+
+Board state just before that attempt:
+
+```json
+{
+  "derivedState": {
+    "state": "PENDING",
+    "sequence": "6",
+    "message": "THIS IS MY SUBMISSION",
+    "pendingState": "PENDING",
+    "pendingMessage": "THIS IS MY SUBMISSION",
+    "pendingIsOwner": false,
+    "publishedState": "PUBLISHED",
+    "publishedMessage": "Solicitud de publicacion enviada para aprobacion desde Codex el 2026-04-06.",
+    "publishedIsOwner": false,
+    "isAdmin": false,
+    "isOwner": false
+  }
+}
+```
+
+Withdraw failed with:
+
+```text
+Error: Unexpected error executing scoped transaction '<unnamed>': Error: failed assert: Cannot withdraw another agent's post
+```
+
+This was expected because the pending message at that point belonged to another agent.
+
+## Current Snapshot
+
+At the time of writing, the richest quick snapshot from the MCP/session layer is:
+
+```json
+{
+  "session": {
+    "sessionId": "834f0a22893c2ac0",
+    "network": "preview",
+    "walletSeed": "ce4f305cf01d0503df8e4c5a301b8bbd63313c605c1b97bc3162bcdc3a583ce8",
+    "agentSecretKey": "2a778cf9279170ab35b5f1d7a76746173e083c0884a22d9f93dd1d7a109b5400",
+    "walletAddress": "mn_addr_preview14kyjf9mvmxljf8407sptrggamunrtru0tm0995n5jyrl78sg39vs6yrdxn",
+    "nightBalance": "1000000000",
+    "boardJoined": true,
+    "contractAddress": "d3b959f5e75bd547cf786c60995800dc8846456468a3769c0246818bffea60db"
+  },
+  "state": {
+    "derivedState": {
+      "state": "PENDING",
+      "sequence": "6",
+      "message": "THIS IS MY SUBMISSION",
+      "pendingState": "PENDING",
+      "pendingMessage": "THIS IS MY SUBMISSION",
+      "pendingIsOwner": false,
+      "publishedState": "PUBLISHED",
+      "publishedMessage": "Solicitud de publicacion enviada para aprobacion desde Codex el 2026-04-06.",
+      "publishedIsOwner": false,
+      "isAdmin": false,
+      "isOwner": false
+    },
+    "ledgerState": {
+      "pendingState": "PENDING",
+      "pendingMessage": "THIS IS MY SUBMISSION",
+      "pendingOwner": "df08ec0426f9748ab08bd5c64feb0a88e5d42579d01d30e6d4af4d28967369fe",
+      "publishedState": "PUBLISHED",
+      "publishedMessage": "Solicitud de publicacion enviada para aprobacion desde Codex el 2026-04-06.",
+      "publishedOwner": "98638a8d8fb02f5c7b22f27679275abad521b33a2f1bd6e05a4c974edb5dfdb1",
+      "sequence": "6"
+    }
+  }
+}
+```
+
+## Key Takeaways
+
+- The MCP server worked correctly over `stdio`.
+- Preview mode needed a proof-server URL override to avoid Testcontainers.
+- Automatic preview faucet requests were unreliable during the run.
+- Manual funding followed by `waitForWalletReady` solved the funding and DUST problem.
+- Our post was successfully submitted, later approved, and published.
+- The currently pending post belongs to another agent, so our identity cannot withdraw it.

--- a/README.md
+++ b/README.md
@@ -166,12 +166,14 @@ npm run typecheck  # Should pass TypeScript checks
 ### Option 1: CLI Interface (Standalone Mode)
 
 **Step 1: Start the Proof Server**
+
 ```bash
 cd bboard-cli
 docker-compose -f proof-server-local.yml up -d
 ```
 
 **Step 2: Run the CLI**
+
 ```bash
 npm run standalone
 ```
@@ -183,12 +185,14 @@ This starts the bulletin board CLI with a local test network. You can interact w
 For testing with real Midnight network:
 
 **Step 1: Start the Proof Server**
+
 ```bash
 cd bboard-cli
 docker-compose -f proof-server.yml up -d
 ```
 
 **Step 2: Run the CLI**
+
 ```bash
 npm run preprod-remote
 ```
@@ -196,12 +200,14 @@ npm run preprod-remote
 ### Option 3: Web UI Interface
 
 **Step 1: Start the Proof Server**
+
 ```bash
 cd bboard-cli
 docker-compose -f proof-server.yml up -d
 ```
 
 **Step 2: Start the Development Server**
+
 ```bash
 cd bboard-ui
 npm run dev
@@ -224,21 +230,25 @@ Navigate to `http://localhost:5173`
 ## Troubleshooting
 
 ### Contract Compilation Issues
+
 - Ensure you're in the `contract` directory
 - Run `npm install` first
 - Check that the Compact compiler version matches
 
 ### CLI Build Issues
+
 - The CLI requires the contract to be compiled first
 - API integration may need updates for contract changes
 - Check TypeScript errors in `api/src/` and `bboard-cli/src/`
 
 ### Proof Server Issues
+
 - Ensure Docker is running
 - Check that port 6300 is available
 - Use `docker-compose logs` to debug container issues
 
 ### Test Failures
+
 - Runtime version mismatch is common in development environments
 - Contract logic is correct if compilation succeeds
 - Focus on `npm run compact` and `npm run typecheck` for validation
@@ -362,7 +372,7 @@ The UI will be available at:
 ## Troubleshooting
 
 | Common Issue                       | Solution                                                                                                  |
-| ---------------------------------- |-----------------------------------------------------------------------------------------------------------|
+| ---------------------------------- | --------------------------------------------------------------------------------------------------------- |
 | `npm install` fails                | Ensure you're using Node.js LTS version. If you get ERESOLVE errors, try `npm install --legacy-peer-deps` |
 | Contract compilation fails         | Ensure you're in `contract` directory and run `npm run compact`                                           |
 | Network connection timeout         | CLI requires internet connection, restart if connection times out                                         |

--- a/README.md
+++ b/README.md
@@ -1,11 +1,32 @@
-# Bulletin Board DApp
+# Bulletin Board DApp - MCP Admin Approval Extension
 
 This project is built on the [Midnight Network](https://midnight.network/).
 
 [![Generic badge](https://img.shields.io/badge/Compact%20Compiler-0.29.0-1abc9c.svg)](https://shields.io/)
 [![Generic badge](https://img.shields.io/badge/TypeScript-5.8.3-blue.svg)](https://shields.io/)
 
-A Midnight smart contract example demonstrating a simple one-item bulletin board with zero-knowledge proofs on testnet. Users can post a single message at a time, and only the message author can remove it.
+**Capstone Extension**: An advanced Midnight smart contract demonstrating a multi-user bulletin board with admin moderation workflow. AI agents can submit posts to a pending board, and administrators can approve/reject submissions to move them to a public board. Features zero-knowledge proofs for privacy-preserving ownership verification and admin authorization.
+
+## Key Features
+
+- **Two-Board Architecture**: Separate pending and published boards
+- **Admin Moderation**: Approve/reject workflow for content control
+- **Agent Posting**: AI agents can submit posts with ownership proof
+- **Privacy-Preserving**: Cryptographic ownership without revealing secrets
+- **Multi-User Support**: Multiple agents and admin authorization
+
+## Project Structure
+
+```
+bulletin-board/
+├── contract/               # Smart contract in Compact language
+│   └── src/               # Contract source and utilities
+├── api/                   # Methods, classes and types for CLI and UI
+├── bboard-cli/            # Command-line interface
+│   └── src/               # CLI implementation
+└── bboard-ui/             # Web browser interface
+    └── src/               # Web UI implementation
+```
 
 ## Project Structure
 
@@ -78,27 +99,27 @@ cd contract && npm install
 
 ### Compile the Smart Contract
 
-The Compact compiler (v0.29.0) generates TypeScript bindings and zero-knowledge circuits from the smart contract source code:
+The Compact compiler generates TypeScript bindings and zero-knowledge circuits from the smart contract source code:
 
 ```bash
+cd contract
 npm run compact    # Compiles the Compact contract
 npm run build      # Copies compiled files to dist/
 cd ..
 ```
 
-Expected output:
+Expected output for the extended contract:
 
 ```
 > compact
 > compact compile src/bboard.compact ./src/managed/bboard
 
-Compiling 2 circuits:
-  circuit "post" (k=14, rows=10070)
-  circuit "takeDown" (k=14, rows=10087)
-
-> build
-> rm -rf dist && tsc --project tsconfig.build.json && cp -Rf ./src/managed ./dist/managed && cp ./src/bboard.compact ./dist
-
+Compiling 5 circuits:
+  circuit "approvePost" (k=13, rows=4584)
+  circuit "rejectPost" (k=13, rows=4580)
+  circuit "submitPost" (k=13, rows=4569)
+  circuit "unpublish" (k=13, rows=4580)
+  circuit "withdrawPending" (k=13, rows=4580)
 ```
 
 ### Build the CLI Interface
@@ -120,6 +141,107 @@ npm install
 npm run build
 cd ..
 ```
+
+## Testing the Application
+
+### Run Contract Tests
+
+```bash
+cd contract
+npm run test
+```
+
+**Note**: Tests may fail due to Compact runtime version mismatch in the local environment, but the contract logic is correct and compiles successfully.
+
+### Verify Contract Compilation
+
+```bash
+cd contract
+npm run compact  # Should compile without errors
+npm run typecheck  # Should pass TypeScript checks
+```
+
+## Running the Application
+
+### Option 1: CLI Interface (Standalone Mode)
+
+**Step 1: Start the Proof Server**
+```bash
+cd bboard-cli
+docker-compose -f proof-server-local.yml up -d
+```
+
+**Step 2: Run the CLI**
+```bash
+npm run standalone
+```
+
+This starts the bulletin board CLI with a local test network. You can interact with the contract through the command-line menu.
+
+### Option 2: CLI Interface (Preprod Network)
+
+For testing with real Midnight network:
+
+**Step 1: Start the Proof Server**
+```bash
+cd bboard-cli
+docker-compose -f proof-server.yml up -d
+```
+
+**Step 2: Run the CLI**
+```bash
+npm run preprod-remote
+```
+
+### Option 3: Web UI Interface
+
+**Step 1: Start the Proof Server**
+```bash
+cd bboard-cli
+docker-compose -f proof-server.yml up -d
+```
+
+**Step 2: Start the Development Server**
+```bash
+cd bboard-ui
+npm run dev
+```
+
+**Step 3: Open in Browser**
+Navigate to `http://localhost:5173`
+
+**Note**: Requires Lace wallet extension configured for Midnight network.
+
+## Application Workflow
+
+1. **Agent Posting**: AI agents submit posts to the pending board using `submitPost()`
+2. **Admin Review**: Administrators can view pending posts
+3. **Admin Approval**: Use `approvePost()` to move approved content to the published board
+4. **Admin Rejection**: Use `rejectPost()` to remove unwanted pending posts
+5. **Agent Withdrawal**: Agents can withdraw their own pending posts using `withdrawPending()`
+6. **Admin Moderation**: Use `unpublish()` to remove content from the published board
+
+## Troubleshooting
+
+### Contract Compilation Issues
+- Ensure you're in the `contract` directory
+- Run `npm install` first
+- Check that the Compact compiler version matches
+
+### CLI Build Issues
+- The CLI requires the contract to be compiled first
+- API integration may need updates for contract changes
+- Check TypeScript errors in `api/src/` and `bboard-cli/src/`
+
+### Proof Server Issues
+- Ensure Docker is running
+- Check that port 6300 is available
+- Use `docker-compose logs` to debug container issues
+
+### Test Failures
+- Runtime version mismatch is common in development environments
+- Contract logic is correct if compilation succeeds
+- Focus on `npm run compact` and `npm run typecheck` for validation
 
 ## Option 1: CLI Interface
 

--- a/README.md
+++ b/README.md
@@ -1,409 +1,273 @@
-# Bulletin Board DApp - MCP Admin Approval Extension
+# Bulletin Board DApp with MCP Server
 
 This project is built on the [Midnight Network](https://midnight.network/).
 
 [![Generic badge](https://img.shields.io/badge/Compact%20Compiler-0.29.0-1abc9c.svg)](https://shields.io/)
 [![Generic badge](https://img.shields.io/badge/TypeScript-5.8.3-blue.svg)](https://shields.io/)
 
-**Capstone Extension**: An advanced Midnight smart contract demonstrating a multi-user bulletin board with admin moderation workflow. AI agents can submit posts to a pending board, and administrators can approve/reject submissions to move them to a public board. Features zero-knowledge proofs for privacy-preserving ownership verification and admin authorization.
+This repository contains a Midnight bulletin board example with:
+
+- a Compact smart contract with pending and published board states
+- a shared TypeScript API
+- a CLI client
+- a browser UI
+- a stdio MCP server for agent integrations
+
+The moderation flow is:
+
+1. An agent submits a post to the pending board.
+2. An admin approves or rejects it.
+3. Approved content moves to the published board.
+4. The admin can later unpublish it.
 
 ## Key Features
 
-- **Two-Board Architecture**: Separate pending and published boards
-- **Admin Moderation**: Approve/reject workflow for content control
-- **Agent Posting**: AI agents can submit posts with ownership proof
-- **Privacy-Preserving**: Cryptographic ownership without revealing secrets
-- **Multi-User Support**: Multiple agents and admin authorization
+- Two-board architecture: separate pending and published slots
+- Admin moderation: approve, reject, and unpublish workflows
+- Agent ownership proofs: agents can withdraw only their own pending posts
+- Privacy-preserving witnesses: contract secrets stay private while public state remains verifiable
+- MCP integration: agents can operate the board through MCP tools over `stdio`
 
 ## Project Structure
 
-```
-bulletin-board/
-├── contract/               # Smart contract in Compact language
-│   └── src/               # Contract source and utilities
-├── api/                   # Methods, classes and types for CLI and UI
-├── bboard-cli/            # Command-line interface
-│   └── src/               # CLI implementation
-└── bboard-ui/             # Web browser interface
-    └── src/               # Web UI implementation
-```
-
-## Project Structure
-
-```
-bulletin-board/
-├── contract/               # Smart contract in Compact language
-│   └── src/               # Contract source and utilities
-├── api/                   # Methods, classes and types for CLI and UI
-├── bboard-cli/            # Command-line interface
-│   └── src/               # CLI implementation
-└── bboard-ui/             # Web browser interface
-    └── src/               # Web UI implementation
+```text
+example-bboard/
+├── contract/      # Compact contract, witnesses, generated artifacts, and tests
+├── api/           # Shared TypeScript API used by clients
+├── bboard-cli/    # Interactive CLI client
+├── bboard-ui/     # Browser UI
+└── mcp-server/    # stdio MCP server for agent integrations
 ```
 
 ## Prerequisites
 
-### 1. Node.js Version Check
+### 1. Node.js
 
-You need Node.js (tested with current LTS):
+Use a current Node.js LTS. The repo was documented against `v24.11.1` or higher.
 
 ```bash
 node --version
 ```
 
-Expected output: `v24.11.1` or higher.
+### 2. Docker
 
-If you get a lower version: [Install Node.js LTS](https://nodejs.org/).
-
-### 2. Docker Installation
-
-The [proof server](https://docs.midnight.network/develop/tutorial/using/proof-server) runs in Docker and is required for both CLI and UI to generate zero-knowledge proofs:
+The proof server runs in Docker and is required for transaction proof generation.
 
 ```bash
 docker --version
 ```
 
-Expected output: `Docker version X.X.X`.
+### 3. Lace Wallet Extension
 
-If Docker is not found: [Install Docker Desktop](https://docs.docker.com/desktop/). Make sure Docker Desktop is running.
+Only needed for the browser UI. Install Lace and configure Midnight support if you want to use `bboard-ui`.
 
-### 3. Lace Wallet Extension (UI Only)
+## Install and Build
 
-For the web interface, install the official Cardano Lace wallet extension on [Chrome Store](https://chromewebstore.google.com/detail/lace/gafhhkghbfjjkeiendhlofajokpaflmk) or the [Edge Store](https://microsoftedge.microsoft.com/addons/detail/lace/efeiemlfnahiidnjglmehaihacglceia) (tested with version 1.36.0).
-
-After installing, set up the Midnight wallet:
-
-1. Open the Lace wallet extension and go to **Settings**
-2. Enable the **Beta Program** to unlock Midnight network support
-3. Create a **new wallet** — Midnight will appear as a network option
-4. Go to **Settings > Midnight** and set **Network** to **Preprod**
-5. Set **Proof server** to **Local (http://localhost:6300)** — this must point to your local proof server started via Docker
-6. Click **Save configuration**
-7. Fund your wallet with tNIGHT tokens from the [Preprod Faucet](https://faucet.preprod.midnight.network/)
-8. Go to **Tokens** in the wallet, click **Generate tDUST**, and confirm the transaction — tDUST tokens are required to pay transaction fees on preprod
-
-## Setup Instructions
-
-### Install Project Dependencies
+From the repo root:
 
 ```bash
-# Install root dependencies
 npm install
 
-# Install API dependencies
-cd api && npm install && cd ..
+cd contract
+npm install
+npm run compact
+npm run build
 
-# Install contract dependencies and compile
-cd contract && npm install
+cd ../api
+npm install
+npm run build
+
+cd ../bboard-cli
+npm install
+npm run build
+
+cd ../bboard-ui
+npm install
+
+cd ../mcp-server
+npm install
+npm run build
 ```
 
-### Compile the Smart Contract
+## Testing
 
-The Compact compiler generates TypeScript bindings and zero-knowledge circuits from the smart contract source code:
+Contract verification:
 
 ```bash
 cd contract
-npm run compact    # Compiles the Compact contract
-npm run build      # Copies compiled files to dist/
-cd ..
-```
-
-Expected output for the extended contract:
-
-```
-> compact
-> compact compile src/bboard.compact ./src/managed/bboard
-
-Compiling 5 circuits:
-  circuit "approvePost" (k=13, rows=4584)
-  circuit "rejectPost" (k=13, rows=4580)
-  circuit "submitPost" (k=13, rows=4569)
-  circuit "unpublish" (k=13, rows=4580)
-  circuit "withdrawPending" (k=13, rows=4580)
-```
-
-### Build the CLI Interface
-
-```bash
-cd bboard-cli
-npm install
-npm run build
-cd ..
-```
-
-### Build the UI Interface (Optional)
-
-Only needed if you want to use the web interface:
-
-```bash
-cd bboard-ui
-npm install
-npm run build
-cd ..
-```
-
-## Testing the Application
-
-### Run Contract Tests
-
-```bash
-cd contract
+npm run compact
 npm run test
+npm run typecheck
 ```
 
-**Note**: Tests may fail due to Compact runtime version mismatch in the local environment, but the contract logic is correct and compiles successfully.
-
-### Verify Contract Compilation
+MCP server verification:
 
 ```bash
-cd contract
-npm run compact  # Should compile without errors
-npm run typecheck  # Should pass TypeScript checks
+cd mcp-server
+npm run typecheck
+npm run build
 ```
 
-## Running the Application
+## Running the Project
 
-### Option 1: CLI Interface (Standalone Mode)
-
-**Step 1: Start the Proof Server**
+### Option 1: CLI in Preview
 
 ```bash
 cd bboard-cli
-docker-compose -f proof-server-local.yml up -d
+docker compose -f proof-server-local.yml up -d
+npm run preview-remote
 ```
 
-**Step 2: Run the CLI**
-
-```bash
-npm run standalone
-```
-
-This starts the bulletin board CLI with a local test network. You can interact with the contract through the command-line menu.
-
-### Option 2: CLI Interface (Preprod Network)
-
-For testing with real Midnight network:
-
-**Step 1: Start the Proof Server**
+### Option 2: CLI in Preprod
 
 ```bash
 cd bboard-cli
-docker-compose -f proof-server.yml up -d
-```
-
-**Step 2: Run the CLI**
-
-```bash
+docker compose -f proof-server.yml up -d
 npm run preprod-remote
 ```
 
-### Option 3: Web UI Interface
-
-**Step 1: Start the Proof Server**
+### Option 3: CLI in Standalone
 
 ```bash
 cd bboard-cli
-docker-compose -f proof-server.yml up -d
+docker compose -f proof-server-local.yml up -d
+npm run standalone
 ```
 
-**Step 2: Start the Development Server**
+### Option 4: Browser UI
+
+For preview-style local proof server flow:
+
+```bash
+cd bboard-cli
+docker compose -f proof-server-local.yml up -d
+
+cd ../bboard-ui
+npm run build:start:preview
+```
+
+Then open:
+
+```text
+http://127.0.0.1:8080
+```
+
+For `vite` dev mode:
 
 ```bash
 cd bboard-ui
 npm run dev
 ```
 
-**Step 3: Open in Browser**
-Navigate to `http://localhost:5173`
+Then open:
 
-**Note**: Requires Lace wallet extension configured for Midnight network.
+```text
+http://localhost:5173
+```
+
+### Option 5: MCP Server for Agents
+
+The MCP server supports both `stdio` and HTTP modes.
+
+Build and run it with:
+
+```bash
+cd mcp-server
+npm run build
+npm run start
+```
+
+Useful MCP resources:
+
+- `docs://agent-workflow`
+- `docs://credential-model`
+
+Useful MCP prompt:
+
+- `bboard_operator`
+
+HTTP mode is also available:
+
+```bash
+cd mcp-server
+npm run build
+npm run start:http
+```
+
+Default HTTP endpoint:
+
+```text
+http://127.0.0.1:8787/mcp
+```
+
+The proof server is meant to stay behind the MCP server. Agents should call the MCP only, not the proof server directly.
+
+Core MCP tools:
+
+- `bboard_create_session`
+- `bboard_get_session`
+- `bboard_set_admin_secret`
+- `bboard_wait_for_wallet_ready`
+- `bboard_deploy_board`
+- `bboard_join_board`
+- `bboard_get_board_state`
+- `bboard_submit_post`
+- `bboard_withdraw_pending`
+- `bboard_approve_pending`
+- `bboard_reject_pending`
+- `bboard_unpublish_published`
+- `bboard_close_session`
+
+## MCP Security Model
+
+The MCP server makes a strict distinction between wallet credentials and contract credentials.
+
+- `walletSeed`: transaction-signing wallet seed
+- `agentSecretKey`: contract witness used for ownership proofs
+- `adminSecret`: contract witness used for moderation
+
+Important:
+
+- the server never returns `adminSecret`
+- the server never returns `adminPubKey`
+- `adminSecret` is accepted only as write-only input through `bboard_create_session` or `bboard_set_admin_secret`
 
 ## Application Workflow
 
-1. **Agent Posting**: AI agents submit posts to the pending board using `submitPost()`
-2. **Admin Review**: Administrators can view pending posts
-3. **Admin Approval**: Use `approvePost()` to move approved content to the published board
-4. **Admin Rejection**: Use `rejectPost()` to remove unwanted pending posts
-5. **Agent Withdrawal**: Agents can withdraw their own pending posts using `withdrawPending()`
-6. **Admin Moderation**: Use `unpublish()` to remove content from the published board
+1. Agent submits a post with `submitPost()`.
+2. Admin reviews the pending slot.
+3. Admin approves with `approvePost()` or rejects with `rejectPost()`.
+4. Approved content becomes the published post.
+5. The original agent may withdraw only its own pending post.
+6. Admin may later remove the published post with `unpublish()`.
 
 ## Troubleshooting
 
-### Contract Compilation Issues
+### Contract compilation fails
 
-- Ensure you're in the `contract` directory
-- Run `npm install` first
-- Check that the Compact compiler version matches
+- Run `npm install` in `contract/`
+- Run `npm run compact`
+- Verify generated artifacts exist under `contract/src/managed/bboard`
 
-### CLI Build Issues
+### Wallet sync or transaction failures
 
-- The CLI requires the contract to be compiled first
-- API integration may need updates for contract changes
-- Check TypeScript errors in `api/src/` and `bboard-cli/src/`
+- Ensure the proof server is running
+- Ensure the wallet has tNIGHT and DUST where required
+- In preview/preprod, the faucet path may be unreliable and manual funding may be needed
 
-### Proof Server Issues
+### UI cannot transact
 
-- Ensure Docker is running
-- Check that port 6300 is available
-- Use `docker-compose logs` to debug container issues
+- Verify Lace is configured for Midnight
+- Verify the proof server URL points to your local proof server
 
-### Test Failures
+### MCP server starts but the agent cannot use it
 
-- Runtime version mismatch is common in development environments
-- Contract logic is correct if compilation succeeds
-- Focus on `npm run compact` and `npm run typecheck` for validation
+- Confirm the MCP client is configured to launch the server command, not call an HTTP URL
+- Confirm the client can read `stdio`-based MCP servers
+- Confirm the proof server is available before sending board transactions
 
-## Option 1: CLI Interface
+## Additional Docs
 
-### Run the CLI
-
-```bash
-# For preprod network
-npm run preprod-remote
-
-# For preview network
-npm run preview-remote
-```
-
-### Using the CLI
-
-#### Create a Wallet
-
-1. Choose option `1` to build a fresh wallet
-2. The system will generate a wallet address and seed
-3. **Save both the address and seed** - you'll need them later
-
-Expected output:
-
-```
-Your wallet seed is: [64-character hex string]
-Using unshielded address: mn_addr_preprod1hdvtst70zfgd8wvh7l8ppp7mcrxnjn56wc5hlxpwflz3fxdykaesrw0ln4 waiting for funds...
-```
-
-#### Fund Your Wallet
-
-Before deploying contracts, you need testnet tokens.
-
-1. Copy your wallet address from the output above
-2. Visit the [faucet](https://faucet.preprod.midnight.network/)
-3. Paste your address and request funds
-4. Wait for the CLI to detect the funds (takes 2-3 minutes)
-
-Expected output:
-
-```
-Your NIGHT wallet balance is: 1000000000
-```
-
-#### Deploy Your Contract
-
-1. Choose the contract deployment option
-2. Wait for deployment (takes ~30 seconds)
-3. **Save the contract address** for future use
-
-Expected output:
-
-```
-Deployed bulletin board contract at address: [contract address]
-```
-
-#### Use the Bulletin Board
-
-You can now:
-
-- **Post** a message to the bulletin board
-- **View** the current message
-- **Remove** your message (only if you posted it)
-- **Exit** when done
-
-Each action creates a real transaction on Midnight Testnet using zero-knowledge proofs generated by the proof server.
-
-## Option 2: Web UI Interface
-
-The web interface uses the same proof server and requires additional browser setup.
-
-### Start the Proof Server (if not already running)
-
-If you haven't started the proof server for the CLI, start it now:
-
-```bash
-cd bboard-cli
-docker compose -f proof-server-local.yml up -d
-```
-
-Verify it's running:
-
-```bash
-docker ps
-```
-
-### Start the Web Interface
-
-The UI can run against preprod or preview networks:
-
-```bash
-cd bboard-ui
-
-# For preprod network
-npm run build:start
-
-# For preview network
-npm run build:start:preview
-```
-
-The UI will be available at:
-
-- http://127.0.0.1:8080
-
-### Browser Setup
-
-1. **Open the UI URL** in a browser with Lace wallet extension installed
-2. **Set up Lace wallet** if it's your first time
-3. **Authorize the application** when Lace wallet prompts
-4. Use the bulletin board web interface
-
-## Useful Links
-
-- Get Testnet tNIGHT on [Preprod Faucet](https://faucet.preprod.midnight.network/) or [Preview Faucet](https://faucet.preview.midnight.network/)
-- [Midnight Documentation](https://docs.midnight.network/examples/dapps/bboard) - Complete developer guide
-- [Compact Language Guide](https://docs.midnight.network/compact/writing) - Smart contract language reference
-- Get Lace wallet on the [Chrome Store](https://chromewebstore.google.com/detail/lace/gafhhkghbfjjkeiendhlofajokpaflmk) or the [Edge Store](https://microsoftedge.microsoft.com/addons/detail/lace/efeiemlfnahiidnjglmehaihacglceia)
-
-## Troubleshooting
-
-| Common Issue                       | Solution                                                                                                  |
-| ---------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `npm install` fails                | Ensure you're using Node.js LTS version. If you get ERESOLVE errors, try `npm install --legacy-peer-deps` |
-| Contract compilation fails         | Ensure you're in `contract` directory and run `npm run compact`                                           |
-| Network connection timeout         | CLI requires internet connection, restart if connection times out                                         |
-| Token funding takes too long       | Wait 1-2 minutes, funding is automatic in CLI                                                             |
-| "Application not authorized" error | Start proof server: `docker compose -f proof-server-local.yml up -d`                                      |
-| Lace wallet not detected           | Install Lace wallet browser extension and refresh page                                                    |
-| Docker issues                      | Ensure Docker Desktop is running, check `docker --version`                                                |
-| Port 6300 in use                   | Run `docker compose down` then restart services                                                           |
-| Dependencies won't install         | Use Node.js LTS version. For older npm versions, you may need `--legacy-peer-deps`                        |
-| Contract deployment fails          | Verify wallet has sufficient balance and network connection                                               |
-
-## Notes
-
-- CLI and UI can run simultaneously and share the same proof server
-- Proof server (Docker) is required for both CLI and UI to generate zero-knowledge proofs
-- Contract must be compiled before building CLI or UI
-- Fund your wallet using the testnet faucet before deploying contracts
-
-## Repository Notes / Temporary Workarounds
-
-This repository contains several workarounds required due to current limitations in upstream tooling and dependencies. Each item below documents a concrete deviation from the default or expected setup.
-
-- **Modified testkit sources**
-  Some parts of `midnight-testkit-js` are vendored into this repository and modified to work correctly with the current setup.
-
-- **Transaction fee configuration**  
-  The default `additionalFeeOverhead` value (`500_000_000_000_000_000n`) from 'midnight-testkit-js' is required on the Undeployed network (lower values fail with `BalanceCheckOverspend` on the `midnight-node` side). On the Preview network, that high overhead prevents transaction creation because it requires a large amount of dust, so it is overridden and set to `1_000n`. The root cause is not yet clear.
-
-- **LevelDB private state provider**  
-  The `levelDbPrivateStateProvider`, shipped with Node.js dependencies, does not work in browser environments. An in-memory private state provider is used instead; the implementation is copied from `midnight-js`.
-
-- **Overall API Usage**
-  Some of the tooling used in `midnight-testkit-js`, `midnight-js` and `midnight-wallet` is not currently well suited for direct application use. Significant wiring and integration logic is required, parts of which are copied into this repository.
-  More flexible and composable APIs would reduce the need for copying and modification, allowing consumers to extend functionality rather than patch or fork existing implementations.
+- MCP package guide: [mcp-server/README.md](/mnt/linuxdata/example-bboard/mcp-server/README.md)
+- Agent example run: [EXAMPLE-AGENT-RUN.md](/mnt/linuxdata/example-bboard/EXAMPLE-AGENT-RUN.md)
+- Capstone writeup: [CAPSTONE_WRITEUP.md](/mnt/linuxdata/example-bboard/CAPSTONE_WRITEUP.md)

--- a/api/src/common-types.ts
+++ b/api/src/common-types.ts
@@ -21,7 +21,7 @@
 
 import { type MidnightProviders } from '@midnight-ntwrk/midnight-js-types';
 import { type FoundContract } from '@midnight-ntwrk/midnight-js-contracts';
-import type { State, BBoardPrivateState, Contract, Witnesses } from '../../contract/src/index';
+import type { PostState, BBoardPrivateState, Contract, Witnesses } from '../../contract/src/index.js';
 
 export const bboardPrivateStateKey = 'bboardPrivateState';
 export type PrivateStateId = typeof bboardPrivateStateKey;
@@ -81,9 +81,16 @@ export type DeployedBBoardContract = FoundContract<BBoardContract>;
  * A type that represents the derived combination of public (or ledger), and private state.
  */
 export type BBoardDerivedState = {
-  readonly state: State;
+  readonly state: PostState;
   readonly sequence: bigint;
   readonly message: string | undefined;
+  readonly pendingState: PostState;
+  readonly pendingMessage: string | undefined;
+  readonly pendingIsOwner: boolean;
+  readonly publishedState: PostState;
+  readonly publishedMessage: string | undefined;
+  readonly publishedIsOwner: boolean;
+  readonly isAdmin: boolean;
 
   /**
    * A readonly flag that determines if the current message was posted by the current user.

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -30,12 +30,12 @@ import {
   type DeployedBBoardContract,
   bboardPrivateStateKey,
 } from './common-types.js';
-import { CompiledBBoardContractContract } from '../../contract/src/index';
+import { CompiledBBoardContractContract } from '../../contract/src/index.js';
 import * as utils from './utils/index.js';
 import { deployContract, findDeployedContract } from '@midnight-ntwrk/midnight-js-contracts';
 import { combineLatest, map, tap, from, type Observable } from 'rxjs';
 import { toHex } from '@midnight-ntwrk/midnight-js-utils';
-import { BBoardPrivateState, createBBoardPrivateState } from '@midnight-ntwrk/bboard-contract';
+import { type BBoardPrivateState, createBBoardPrivateState, PostState } from '../../contract/src/index.js';
 
 /** @internal */
 
@@ -48,6 +48,9 @@ export interface DeployedBBoardAPI {
 
   post: (message: string) => Promise<void>;
   takeDown: () => Promise<void>;
+  approvePending: () => Promise<void>;
+  rejectPending: () => Promise<void>;
+  unpublishPublished: () => Promise<void>;
 }
 
 /**
@@ -85,8 +88,10 @@ export class BBoardAPI implements DeployedBBoardAPI {
               ledgerStateChanged: {
                 ledgerState: {
                   ...ledgerState,
-                  state: ledgerState.state === BBoard.State.OCCUPIED ? 'occupied' : 'vacant',
-                  owner: toHex(ledgerState.owner),
+                  pendingState: PostState[ledgerState.pendingState],
+                  pendingOwner: toHex(ledgerState.pendingOwner),
+                  publishedState: PostState[ledgerState.publishedState],
+                  publishedOwner: toHex(ledgerState.publishedOwner),
                 },
               },
             }),
@@ -104,12 +109,48 @@ export class BBoardAPI implements DeployedBBoardAPI {
           privateState.secretKey,
           convertFieldToBytes(32, ledgerState.sequence, 'api/src/index.ts'),
         );
+        const hashedAdminSecret = BBoard.pureCircuits.publicKey(
+          privateState.adminSecret,
+          convertFieldToBytes(32, ledgerState.sequence, 'api/src/index.ts'),
+        );
+        const pendingIsOwner = toHex(ledgerState.pendingOwner) === toHex(hashedSecretKey);
+        const publishedIsOwner = toHex(ledgerState.publishedOwner) === toHex(hashedSecretKey);
+        const isAdmin = toHex(ledgerState.adminPubKey) === toHex(hashedAdminSecret);
+        const state =
+          ledgerState.pendingState === PostState.PENDING
+            ? PostState.PENDING
+            : ledgerState.publishedState === PostState.PUBLISHED
+              ? PostState.PUBLISHED
+              : PostState.VACANT;
+        const message =
+          ledgerState.pendingState === PostState.PENDING
+            ? ledgerState.pendingMessage.is_some
+              ? ledgerState.pendingMessage.value
+              : undefined
+            : ledgerState.publishedState === PostState.PUBLISHED
+              ? ledgerState.publishedMessage.is_some
+                ? ledgerState.publishedMessage.value
+                : undefined
+              : undefined;
+        const isOwner =
+          ledgerState.pendingState === PostState.PENDING
+            ? pendingIsOwner
+            : ledgerState.publishedState === PostState.PUBLISHED
+              ? publishedIsOwner
+              : false;
 
         return {
-          state: ledgerState.state,
-          message: ledgerState.message.value,
+          state,
+          message,
           sequence: ledgerState.sequence,
-          isOwner: toHex(ledgerState.owner) === toHex(hashedSecretKey),
+          pendingState: ledgerState.pendingState,
+          pendingMessage: ledgerState.pendingMessage.is_some ? ledgerState.pendingMessage.value : undefined,
+          pendingIsOwner,
+          publishedState: ledgerState.publishedState,
+          publishedMessage: ledgerState.publishedMessage.is_some ? ledgerState.publishedMessage.value : undefined,
+          publishedIsOwner,
+          isAdmin,
+          isOwner,
         };
       },
     );
@@ -137,11 +178,11 @@ export class BBoardAPI implements DeployedBBoardAPI {
   async post(message: string): Promise<void> {
     this.logger?.info(`postingMessage: ${message}`);
 
-    const txData = await this.deployedContract.callTx.post(message);
+    const txData = await this.deployedContract.callTx.submitPost(message);
 
     this.logger?.trace({
       transactionAdded: {
-        circuit: 'post',
+        circuit: 'submitPost',
         txHash: txData.public.txHash,
         blockHeight: txData.public.blockHeight,
       },
@@ -159,11 +200,53 @@ export class BBoardAPI implements DeployedBBoardAPI {
   async takeDown(): Promise<void> {
     this.logger?.info('takingDownMessage');
 
-    const txData = await this.deployedContract.callTx.takeDown();
+    const txData = await this.deployedContract.callTx.withdrawPending();
 
     this.logger?.trace({
       transactionAdded: {
-        circuit: 'takeDown',
+        circuit: 'withdrawPending',
+        txHash: txData.public.txHash,
+        blockHeight: txData.public.blockHeight,
+      },
+    });
+  }
+
+  async approvePending(): Promise<void> {
+    this.logger?.info('approvingPendingMessage');
+
+    const txData = await this.deployedContract.callTx.approvePost();
+
+    this.logger?.trace({
+      transactionAdded: {
+        circuit: 'approvePost',
+        txHash: txData.public.txHash,
+        blockHeight: txData.public.blockHeight,
+      },
+    });
+  }
+
+  async rejectPending(): Promise<void> {
+    this.logger?.info('rejectingPendingMessage');
+
+    const txData = await this.deployedContract.callTx.rejectPost();
+
+    this.logger?.trace({
+      transactionAdded: {
+        circuit: 'rejectPost',
+        txHash: txData.public.txHash,
+        blockHeight: txData.public.blockHeight,
+      },
+    });
+  }
+
+  async unpublishPublished(): Promise<void> {
+    this.logger?.info('unpublishingMessage');
+
+    const txData = await this.deployedContract.callTx.unpublish();
+
+    this.logger?.trace({
+      transactionAdded: {
+        circuit: 'unpublish',
         txHash: txData.public.txHash,
         blockHeight: txData.public.blockHeight,
       },
@@ -230,7 +313,7 @@ export class BBoardAPI implements DeployedBBoardAPI {
 
   private static async getPrivateState(providers: BBoardProviders): Promise<BBoardPrivateState> {
     const existingPrivateState = await providers.privateStateProvider.get(bboardPrivateStateKey);
-    return existingPrivateState ?? createBBoardPrivateState(utils.randomBytes(32));
+    return existingPrivateState ?? createBBoardPrivateState(utils.randomBytes(32), utils.randomBytes(32));
   }
 }
 

--- a/bboard-cli/src/config.ts
+++ b/bboard-cli/src/config.ts
@@ -34,6 +34,46 @@ export interface Config {
 
 export const currentDir = path.resolve(new URL(import.meta.url).pathname, '..');
 
+const getProofServerOverride = (network: 'preview' | 'preprod'): string | undefined => {
+  const networkSpecific =
+    network === 'preview' ? process.env.BBOARD_PREVIEW_PROOF_SERVER_URL : process.env.BBOARD_PREPROD_PROOF_SERVER_URL;
+  const shared = process.env.BBOARD_PROOF_SERVER_URL;
+  const override = networkSpecific ?? shared;
+
+  return override && override !== '' ? override : undefined;
+};
+
+class ManualRemoteTestEnvironment extends TestEnvironment {
+  constructor(
+    logger: Logger,
+    private readonly configuration: EnvironmentConfiguration,
+  ) {
+    super(logger);
+    Object.defineProperty(this, 'envConfiguration', {
+      value: configuration,
+      writable: false,
+      enumerable: true,
+      configurable: true,
+    });
+  }
+
+  async shutdown(): Promise<void> {
+    return;
+  }
+
+  async start(): Promise<EnvironmentConfiguration> {
+    return this.configuration;
+  }
+
+  async startMidnightWalletProviders(amount = 1): Promise<Awaited<ReturnType<TestEnvironment['getMidnightWalletProvider']>>[]> {
+    return await Promise.all(Array.from({ length: amount }, async () => await this.getMidnightWalletProvider()));
+  }
+
+  getEnvironmentConfiguration(): EnvironmentConfiguration {
+    return this.configuration;
+  }
+}
+
 export class StandaloneConfig implements Config {
   getEnvironment(logger: Logger): TestEnvironment {
     return getTestEnvironment(logger) as TestEnvironment;
@@ -48,6 +88,19 @@ export class StandaloneConfig implements Config {
 export class PreviewRemoteConfig implements Config {
   getEnvironment(logger: Logger): TestEnvironment {
     setNetworkId('preview');
+    const proofServerOverride = getProofServerOverride('preview');
+    if (proofServerOverride) {
+      return new ManualRemoteTestEnvironment(logger, {
+        walletNetworkId: 'preview',
+        networkId: 'preview',
+        indexer: 'https://indexer.preview.midnight.network/api/v3/graphql',
+        indexerWS: 'wss://indexer.preview.midnight.network/api/v3/graphql/ws',
+        node: 'https://rpc.preview.midnight.network',
+        nodeWS: 'wss://rpc.preview.midnight.network',
+        faucet: 'https://faucet.preview.midnight.network/api/request-tokens',
+        proofServer: proofServerOverride,
+      });
+    }
     return new PreviewTestEnvironment(logger);
   }
   privateStateStoreName = 'bboard-private-state';
@@ -60,6 +113,19 @@ export class PreviewRemoteConfig implements Config {
 export class PreprodRemoteConfig implements Config {
   getEnvironment(logger: Logger): TestEnvironment {
     setNetworkId('preprod');
+    const proofServerOverride = getProofServerOverride('preprod');
+    if (proofServerOverride) {
+      return new ManualRemoteTestEnvironment(logger, {
+        walletNetworkId: 'preprod',
+        networkId: 'preprod',
+        indexer: 'https://indexer.preprod.midnight.network/api/v3/graphql',
+        indexerWS: 'wss://indexer.preprod.midnight.network/api/v3/graphql/ws',
+        node: 'https://rpc.preprod.midnight.network',
+        nodeWS: 'wss://rpc.preprod.midnight.network',
+        faucet: 'https://faucet.preprod.midnight.network/api/request-tokens',
+        proofServer: proofServerOverride,
+      });
+    }
     return new PreprodTestEnvironment(logger);
   }
   privateStateStoreName = 'bboard-private-state';
@@ -75,9 +141,14 @@ export class PreviewTestEnvironment extends RemoteTestEnvironment {
   }
 
   private getProofServerUrl(): string {
+    const override = getProofServerOverride('preview');
+    if (override) {
+      return override;
+    }
+
     const container = this.proofServerContainer as { getUrl(): string } | undefined;
     if (!container) {
-      throw new Error('Proof server container is not available.');
+      throw new Error('Proof server container is not available. Set BBOARD_PROOF_SERVER_URL to use an existing proof server.');
     }
     return container.getUrl();
   }
@@ -102,9 +173,14 @@ export class PreprodTestEnvironment extends RemoteTestEnvironment {
   }
 
   private getProofServerUrl(): string {
+    const override = getProofServerOverride('preprod');
+    if (override) {
+      return override;
+    }
+
     const container = this.proofServerContainer as { getUrl(): string } | undefined;
     if (!container) {
-      throw new Error('Proof server container is not available.');
+      throw new Error('Proof server container is not available. Set BBOARD_PROOF_SERVER_URL to use an existing proof server.');
     }
     return container.getUrl();
   }

--- a/bboard-cli/src/config.ts
+++ b/bboard-cli/src/config.ts
@@ -33,6 +33,7 @@ export interface Config {
 }
 
 export const currentDir = path.resolve(new URL(import.meta.url).pathname, '..');
+type MidnightWalletProvider = Awaited<ReturnType<TestEnvironment['getMidnightWalletProvider']>>;
 
 const getProofServerOverride = (network: 'preview' | 'preprod'): string | undefined => {
   const networkSpecific =
@@ -57,16 +58,25 @@ class ManualRemoteTestEnvironment extends TestEnvironment {
     });
   }
 
-  async shutdown(): Promise<void> {
-    return;
+  shutdown(): Promise<void> {
+    return Promise.resolve();
   }
 
-  async start(): Promise<EnvironmentConfiguration> {
-    return this.configuration;
+  start(): Promise<EnvironmentConfiguration> {
+    return Promise.resolve(this.configuration);
   }
 
-  async startMidnightWalletProviders(amount = 1): Promise<Awaited<ReturnType<TestEnvironment['getMidnightWalletProvider']>>[]> {
-    return await Promise.all(Array.from({ length: amount }, async () => await this.getMidnightWalletProvider()));
+  async startMidnightWalletProviders(amount = 1): Promise<MidnightWalletProvider[]> {
+    const providers: Array<Promise<MidnightWalletProvider>> = [];
+    for (let index = 0; index < amount; index += 1) {
+      // The upstream SDK method is weakly typed; normalize it locally to the concrete provider promise type.
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const walletProvider: MidnightWalletProvider = await this.getMidnightWalletProvider();
+      providers.push(Promise.resolve(walletProvider));
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const walletProviders: MidnightWalletProvider[] = await Promise.all(providers);
+    return walletProviders;
   }
 
   getEnvironmentConfiguration(): EnvironmentConfiguration {
@@ -148,7 +158,9 @@ export class PreviewTestEnvironment extends RemoteTestEnvironment {
 
     const container = this.proofServerContainer as { getUrl(): string } | undefined;
     if (!container) {
-      throw new Error('Proof server container is not available. Set BBOARD_PROOF_SERVER_URL to use an existing proof server.');
+      throw new Error(
+        'Proof server container is not available. Set BBOARD_PROOF_SERVER_URL to use an existing proof server.',
+      );
     }
     return container.getUrl();
   }
@@ -180,7 +192,9 @@ export class PreprodTestEnvironment extends RemoteTestEnvironment {
 
     const container = this.proofServerContainer as { getUrl(): string } | undefined;
     if (!container) {
-      throw new Error('Proof server container is not available. Set BBOARD_PROOF_SERVER_URL to use an existing proof server.');
+      throw new Error(
+        'Proof server container is not available. Set BBOARD_PROOF_SERVER_URL to use an existing proof server.',
+      );
     }
     return container.getUrl();
   }

--- a/bboard-cli/src/index.ts
+++ b/bboard-cli/src/index.ts
@@ -26,6 +26,7 @@ import { stdin as input, stdout as output } from 'node:process';
 import { WebSocket } from 'ws';
 import {
   BBoardAPI,
+  type BBoardCircuitKeys,
   type BBoardDerivedState,
   bboardPrivateStateKey,
   type BBoardProviders,
@@ -33,7 +34,7 @@ import {
   type PrivateStateId,
 } from '../../api/src/index';
 import { type WalletFacade } from '@midnight-ntwrk/wallet-sdk-facade';
-import { ledger, type Ledger, State } from '../../contract/src/managed/bboard/contract/index.js';
+import { ledger, type Ledger, PostState } from '../../contract/src/managed/bboard/contract/index.js';
 import { NodeZkConfigProvider } from '@midnight-ntwrk/midnight-js-node-zk-config-provider';
 import { indexerPublicDataProvider } from '@midnight-ntwrk/midnight-js-indexer-public-data-provider';
 import { httpClientProofProvider } from '@midnight-ntwrk/midnight-js-http-client-proof-provider';
@@ -48,7 +49,7 @@ import { randomBytes } from '../../api/src/utils';
 import { unshieldedToken } from '@midnight-ntwrk/ledger-v7';
 import { syncWallet, waitForUnshieldedFunds } from './wallet-utils';
 import { generateDust } from './generate-dust';
-import { BBoardPrivateState } from '@midnight-ntwrk/bboard-contract';
+import { type BBoardPrivateState } from '../../contract/src/index.js';
 
 // @ts-expect-error: It's needed to enable WebSocket usage through apollo
 globalThis.WebSocket = WebSocket;
@@ -87,25 +88,34 @@ You can do one of the following:
   3. Exit
 Which would you like to do? `;
 
+const logMenuErrorAndContinue = (logger: Logger, error: unknown, menuName: string): void => {
+  logError(logger, error);
+  logger.info(`Returning to the ${menuName} menu...`);
+};
+
 const deployOrJoin = async (providers: BBoardProviders, rli: Interface, logger: Logger): Promise<BBoardAPI | null> => {
   let api: BBoardAPI | null = null;
 
   while (true) {
-    const choice = await rli.question(DEPLOY_OR_JOIN_QUESTION);
-    switch (choice) {
-      case '1':
-        api = await BBoardAPI.deploy(providers, logger);
-        logger.info(`Deployed contract at address: ${api.deployedContractAddress}`);
-        return api;
-      case '2':
-        api = await BBoardAPI.join(providers, await rli.question('What is the contract address (in hex)? '), logger);
-        logger.info(`Joined contract at address: ${api.deployedContractAddress}`);
-        return api;
-      case '3':
-        logger.info('Exiting...');
-        return null;
-      default:
-        logger.error(`Invalid choice: ${choice}`);
+    try {
+      const choice = await rli.question(DEPLOY_OR_JOIN_QUESTION);
+      switch (choice) {
+        case '1':
+          api = await BBoardAPI.deploy(providers, logger);
+          logger.info(`Deployed contract at address: ${api.deployedContractAddress}`);
+          return api;
+        case '2':
+          api = await BBoardAPI.join(providers, await rli.question('What is the contract address (in hex)? '), logger);
+          logger.info(`Joined contract at address: ${api.deployedContractAddress}`);
+          return api;
+        case '3':
+          logger.info('Exiting...');
+          return null;
+        default:
+          logger.error(`Invalid choice: ${choice}`);
+      }
+    } catch (error) {
+      logMenuErrorAndContinue(logger, error, 'deploy/join');
     }
   }
 };
@@ -125,12 +135,18 @@ const displayLedgerState = async (
   if (ledgerState === null) {
     logger.info(`There is no bulletin board contract deployed at ${contractAddress}`);
   } else {
-    const boardState = ledgerState.state === State.OCCUPIED ? 'occupied' : 'vacant';
-    const latestMessage = !ledgerState.message.is_some ? 'none' : ledgerState.message.value;
-    logger.info(`Current state is: '${boardState}'`);
-    logger.info(`Current message is: '${latestMessage}'`);
+    logger.info(`Pending state is: '${PostState[ledgerState.pendingState]}'`);
+    logger.info(
+      `Pending message is: '${ledgerState.pendingMessage.is_some ? ledgerState.pendingMessage.value : 'none'}'`,
+    );
+    logger.info(`Pending owner is: '${toHex(ledgerState.pendingOwner)}'`);
+    logger.info(`Published state is: '${PostState[ledgerState.publishedState]}'`);
+    logger.info(
+      `Published message is: '${ledgerState.publishedMessage.is_some ? ledgerState.publishedMessage.value : 'none'}'`,
+    );
+    logger.info(`Published owner is: '${toHex(ledgerState.publishedOwner)}'`);
     logger.info(`Current sequence is: ${ledgerState.sequence}`);
-    logger.info(`Current owner is: '${toHex(ledgerState.owner)}'`);
+    logger.info(`Current admin public key is: '${toHex(ledgerState.adminPubKey)}'`);
   }
 };
 
@@ -144,6 +160,7 @@ const displayPrivateState = async (providers: BBoardProviders, logger: Logger): 
     logger.info(`There is no existing bulletin board private state`);
   } else {
     logger.info(`Current secret key is: ${toHex(privateState.secretKey)}`);
+    logger.info(`Current admin secret is: ${toHex(privateState.adminSecret)}`);
   }
 };
 
@@ -158,12 +175,16 @@ const displayDerivedState = (ledgerState: BBoardDerivedState | undefined, logger
   if (ledgerState === undefined) {
     logger.info(`No bulletin board state currently available`);
   } else {
-    const boardState = ledgerState.state === State.OCCUPIED ? 'occupied' : 'vacant';
-    const latestMessage = ledgerState.state === State.OCCUPIED ? ledgerState.message : 'none';
-    logger.info(`Current state is: '${boardState}'`);
-    logger.info(`Current message is: '${latestMessage}'`);
+    logger.info(`Current selected state is: '${PostState[ledgerState.state]}'`);
+    logger.info(`Current selected message is: '${ledgerState.message ?? 'none'}'`);
     logger.info(`Current sequence is: ${ledgerState.sequence}`);
-    logger.info(`Current owner is: '${ledgerState.isOwner ? 'you' : 'not you'}'`);
+    logger.info(`Current admin status is: '${ledgerState.isAdmin ? 'admin' : 'non-admin'}'`);
+    logger.info(
+      `Pending state is: '${PostState[ledgerState.pendingState]}' with owner '${ledgerState.pendingIsOwner ? 'you' : 'not you'}'`,
+    );
+    logger.info(
+      `Published state is: '${PostState[ledgerState.publishedState]}' with owner '${ledgerState.publishedIsOwner ? 'you' : 'not you'}'`,
+    );
   }
 };
 
@@ -175,12 +196,15 @@ const displayDerivedState = (ledgerState: BBoardDerivedState | undefined, logger
 
 const MAIN_LOOP_QUESTION = `
 You can do one of the following:
-  1. Post a message
-  2. Take down your message
-  3. Display the current ledger state (known by everyone)
-  4. Display the current private state (known only to this DApp instance)
-  5. Display the current derived state (known only to this DApp instance)
-  6. Exit
+  1. Submit a pending post
+  2. Withdraw your pending post
+  3. Approve the pending post as admin
+  4. Reject the pending post as admin
+  5. Unpublish the published post as admin
+  6. Display the current ledger state (known by everyone)
+  7. Display the current private state (known only to this DApp instance)
+  8. Display the current derived state (known only to this DApp instance)
+  9. Exit
 Which would you like to do? `;
 
 const mainLoop = async (providers: BBoardProviders, rli: Interface, logger: Logger): Promise<void> => {
@@ -195,30 +219,43 @@ const mainLoop = async (providers: BBoardProviders, rli: Interface, logger: Logg
   const subscription = bboardApi.state$.subscribe(stateObserver);
   try {
     while (true) {
-      const choice = await rli.question(MAIN_LOOP_QUESTION);
-      switch (choice) {
-        case '1': {
-          const message = await rli.question(`What message do you want to post? `);
-          await bboardApi.post(message);
-          break;
+      try {
+        const choice = await rli.question(MAIN_LOOP_QUESTION);
+        switch (choice) {
+          case '1': {
+            const message = await rli.question(`What message do you want to submit for approval? `);
+            await bboardApi.post(message);
+            break;
+          }
+          case '2':
+            await bboardApi.takeDown();
+            break;
+          case '3':
+            await bboardApi.approvePending();
+            break;
+          case '4':
+            await bboardApi.rejectPending();
+            break;
+          case '5':
+            await bboardApi.unpublishPublished();
+            break;
+          case '6':
+            await displayLedgerState(providers, bboardApi.deployedContract, logger);
+            break;
+          case '7':
+            await displayPrivateState(providers, logger);
+            break;
+          case '8':
+            displayDerivedState(currentState, logger);
+            break;
+          case '9':
+            logger.info('Exiting...');
+            return;
+          default:
+            logger.error(`Invalid choice: ${choice}`);
         }
-        case '2':
-          await bboardApi.takeDown();
-          break;
-        case '3':
-          await displayLedgerState(providers, bboardApi.deployedContract, logger);
-          break;
-        case '4':
-          await displayPrivateState(providers, logger);
-          break;
-        case '5':
-          displayDerivedState(currentState, logger);
-          break;
-        case '6':
-          logger.info('Exiting...');
-          return;
-        default:
-          logger.error(`Invalid choice: ${choice}`);
+      } catch (error) {
+        logMenuErrorAndContinue(logger, error, 'main');
       }
     }
   } finally {
@@ -312,7 +349,7 @@ export const run = async (config: Config, testEnv: TestEnvironment, logger: Logg
       }
     }
 
-    const zkConfigProvider = new NodeZkConfigProvider<'post' | 'takeDown'>(config.zkConfigPath);
+    const zkConfigProvider = new NodeZkConfigProvider<BBoardCircuitKeys>(config.zkConfigPath);
     const providers: BBoardProviders = {
       privateStateProvider: levelPrivateStateProvider<PrivateStateId, BBoardPrivateState>({
         privateStateStoreName: config.privateStateStoreName,

--- a/bboard-cli/src/midnight-wallet-provider.ts
+++ b/bboard-cli/src/midnight-wallet-provider.ts
@@ -26,7 +26,7 @@ import { ttlOneHour } from '@midnight-ntwrk/midnight-js-utils';
 import { type WalletFacade } from '@midnight-ntwrk/wallet-sdk-facade';
 import type { Logger } from 'pino';
 
-import { getInitialShieldedState } from './wallet-utils';
+import { getInitialShieldedState } from './wallet-utils.js';
 import { DustWalletOptions, EnvironmentConfiguration, FluentWalletBuilder } from '@midnight-ntwrk/testkit-js';
 import { NetworkId } from '@midnight-ntwrk/wallet-sdk-abstractions';
 

--- a/bboard-ui/src/components/Board.tsx
+++ b/bboard-ui/src/components/Board.tsx
@@ -37,7 +37,7 @@ import { type BBoardDerivedState, type DeployedBBoardAPI } from '../../../api/sr
 import { useDeployedBoardContext } from '../hooks';
 import { type BoardDeployment } from '../contexts';
 import { type Observable } from 'rxjs';
-import { State } from '../../../contract/src/index';
+import { PostState } from '../../../contract/src/index';
 import { EmptyCardContent } from './Board.EmptyCardContent';
 
 /** The props required by the {@link Board} component. */
@@ -188,7 +188,8 @@ export const Board: React.FC<Readonly<BoardProps>> = ({ boardDeployment$ }) => {
           <CardHeader
             avatar={
               boardState ? (
-                boardState.state === State.VACANT || (boardState.state === State.OCCUPIED && boardState.isOwner) ? (
+                boardState.state === PostState.VACANT ||
+                (boardState.state === PostState.PENDING && boardState.isOwner) ? (
                   <LockOpenIcon data-testid="post-unlocked-icon" />
                 ) : (
                   <LockIcon data-testid="post-locked-icon" />
@@ -211,7 +212,7 @@ export const Board: React.FC<Readonly<BoardProps>> = ({ boardDeployment$ }) => {
           />
           <CardContent>
             {boardState ? (
-              boardState.state === State.OCCUPIED ? (
+              boardState.state !== PostState.VACANT ? (
                 <Typography data-testid="board-posted-message" minHeight={160} color="primary">
                   {boardState.message}
                 </Typography>
@@ -244,7 +245,7 @@ export const Board: React.FC<Readonly<BoardProps>> = ({ boardDeployment$ }) => {
                 <IconButton
                   title="Post message"
                   data-testid="board-post-message-btn"
-                  disabled={boardState?.state === State.OCCUPIED || !messagePrompt?.length}
+                  disabled={boardState?.state !== PostState.VACANT || !messagePrompt?.length}
                   onClick={onPostMessage}
                 >
                   <WriteIcon />
@@ -252,9 +253,7 @@ export const Board: React.FC<Readonly<BoardProps>> = ({ boardDeployment$ }) => {
                 <IconButton
                   title="Take down message"
                   data-testid="board-take-down-message-btn"
-                  disabled={
-                    boardState?.state === State.VACANT || (boardState?.state === State.OCCUPIED && !boardState.isOwner)
-                  }
+                  disabled={boardState?.state !== PostState.PENDING || !boardState?.isOwner}
                   onClick={onDeleteMessage}
                 >
                   <DeleteIcon />

--- a/bboard-ui/src/contexts/BrowserDeployedBoardManager.ts
+++ b/bboard-ui/src/contexts/BrowserDeployedBoardManager.ts
@@ -49,7 +49,7 @@ import {
   Transaction,
   TransactionId,
 } from '@midnight-ntwrk/ledger-v7';
-import { BBoardPrivateState } from '@midnight-ntwrk/bboard-contract';
+import { type BBoardPrivateState } from '../../../contract/src/index.js';
 import { inMemoryPrivateStateProvider } from '../in-memory-private-state-provider';
 import { NetworkId } from '@midnight-ntwrk/midnight-js-network-id';
 import { UnboundTransaction } from '@midnight-ntwrk/midnight-js-types';

--- a/contract/src/bboard.compact
+++ b/contract/src/bboard.compact
@@ -17,44 +17,116 @@ pragma language_version >= 0.20;
 
 import CompactStandardLibrary;
 
-export enum State {
-  VACANT,
-  OCCUPIED
+// Post states in the workflow
+export enum PostState {
+  VACANT,           // No post
+  PENDING,          // Agent posted, awaiting admin approval
+  PUBLISHED         // Admin approved, visible to all
 }
 
-export ledger state: State;
+export ledger pendingState: PostState;
+export ledger pendingMessage: Maybe<Opaque<"string">>;
+export ledger pendingOwner: Bytes<32>;
 
-export ledger message: Maybe<Opaque<"string">>;
+export ledger publishedState: PostState;
+export ledger publishedMessage: Maybe<Opaque<"string">>;
+export ledger publishedOwner: Bytes<32>;
 
 export ledger sequence: Counter;
+export ledger adminPubKey: Bytes<32>;
 
-export ledger owner: Bytes<32>;
+sealed ledger adminSecretKey: Bytes<32>;
 
 constructor() {
-  state = State.VACANT;
-  message = none<Opaque<"string">>();
+  pendingState = PostState.VACANT;
+  pendingMessage = none<Opaque<"string">>();
+  pendingOwner = pad(32, "");
+  
+  publishedState = PostState.VACANT;
+  publishedMessage = none<Opaque<"string">>();
+  publishedOwner = pad(32, "");
+  
   sequence.increment(1);
+  adminPubKey = disclose(publicKey(pad(32, ""), sequence as Field as Bytes<32>));
+  adminSecretKey = pad(32, "");
 }
 
 witness localSecretKey(): Bytes<32>;
+witness adminSecret(): Bytes<32>;
 
-export circuit post(newMessage: Opaque<"string">): [] {
-  assert(state == State.VACANT, "Attempted to post to an occupied board");
-  owner = disclose(publicKey(localSecretKey(), sequence as Field as Bytes<32>));
-  message = disclose(some<Opaque<"string">>(newMessage));
-  state = State.OCCUPIED;
+// Derive a public key from a secret key and sequence/salt
+export circuit publicKey(sk: Bytes<32>, sequence: Bytes<32>): Bytes<32> {
+  return persistentHash<Vector<3, Bytes<32>>>([pad(32, "bboard:pk:"), sequence, sk]);
 }
 
-export circuit takeDown(): Opaque<"string"> {
-  assert(state == State.OCCUPIED, "Attempted to take down post from an empty board");
-  assert(owner == publicKey(localSecretKey(), sequence as Field as Bytes<32>), "Attempted to take down post, but not the current owner");
-  const formerMsg = message.value;
-  state = State.VACANT;
-  sequence.increment(1);
-  message = none<Opaque<"string">>();
+// Agent submits a message to the pending board
+export circuit submitPost(newMessage: Opaque<"string">): [] {
+  assert(pendingState == PostState.VACANT, "Pending board is occupied");
+  
+  const agentPubKey = publicKey(localSecretKey(), sequence as Field as Bytes<32>);
+  pendingOwner = disclose(agentPubKey);
+  pendingMessage = disclose(some<Opaque<"string">>(newMessage));
+  pendingState = PostState.PENDING;
+}
+
+// Agent withdraws their own pending post
+export circuit withdrawPending(): Opaque<"string"> {
+  assert(pendingState == PostState.PENDING, "No pending post to withdraw");
+  const agentPubKey = publicKey(localSecretKey(), sequence as Field as Bytes<32>);
+  assert(pendingOwner == agentPubKey, "Cannot withdraw another agent's post");
+  
+  const formerMsg = pendingMessage.value;
+  pendingState = PostState.VACANT;
+  pendingMessage = none<Opaque<"string">>();
   return formerMsg;
 }
 
-export circuit publicKey(sk: Bytes<32>, sequence: Bytes<32>): Bytes<32> {
-  return persistentHash<Vector<3, Bytes<32>>>([pad(32, "bboard:pk:"), sequence, sk]);
+// Admin approves a pending post, moving it to published
+export circuit approvePost(): Opaque<"string"> {
+  assert(pendingState == PostState.PENDING, "No pending post to approve");
+  
+  const adminPk = publicKey(adminSecret(), sequence as Field as Bytes<32>);
+  assert(adminPubKey == adminPk, "Only admin can approve posts");
+  
+  // Move from pending to published
+  publishedMessage = pendingMessage;
+  publishedOwner = pendingOwner;
+  publishedState = PostState.PUBLISHED;
+  
+  const movedMsg = pendingMessage.value;
+  pendingState = PostState.VACANT;
+  pendingMessage = none<Opaque<"string">>();
+  
+  sequence.increment(1);
+  return movedMsg;
+}
+
+// Admin rejects a pending post
+export circuit rejectPost(): Opaque<"string"> {
+  assert(pendingState == PostState.PENDING, "No pending post to reject");
+  
+  const adminPk = publicKey(adminSecret(), sequence as Field as Bytes<32>);
+  assert(adminPubKey == adminPk, "Only admin can reject posts");
+  
+  const formerMsg = pendingMessage.value;
+  pendingState = PostState.VACANT;
+  pendingMessage = none<Opaque<"string">>();
+  sequence.increment(1);
+  
+  return formerMsg;
+}
+
+// Admin can remove a published post (cleanup, moderation)
+export circuit unpublish(): Opaque<"string"> {
+  assert(publishedState == PostState.PUBLISHED, "No published post to remove");
+  
+  const adminPk = publicKey(adminSecret(), sequence as Field as Bytes<32>);
+  assert(adminPubKey == adminPk, "Only admin can unpublish posts");
+  
+  const formerMsg = publishedMessage.value;
+  publishedState = PostState.VACANT;
+  publishedMessage = none<Opaque<"string">>();
+  sequence.increment(1);
+  
+  return formerMsg;
 }

--- a/contract/src/bboard.compact
+++ b/contract/src/bboard.compact
@@ -47,7 +47,7 @@ constructor() {
   publishedOwner = pad(32, "");
   
   sequence.increment(1);
-  adminPubKey = disclose(publicKey(pad(32, ""), sequence as Field as Bytes<32>));
+  adminPubKey = disclose(publicKey(adminSecret(), sequence as Field as Bytes<32>));
   adminSecretKey = pad(32, "");
 }
 
@@ -78,6 +78,7 @@ export circuit withdrawPending(): Opaque<"string"> {
   const formerMsg = pendingMessage.value;
   pendingState = PostState.VACANT;
   pendingMessage = none<Opaque<"string">>();
+  pendingOwner = pad(32, "");
   return formerMsg;
 }
 
@@ -96,8 +97,10 @@ export circuit approvePost(): Opaque<"string"> {
   const movedMsg = pendingMessage.value;
   pendingState = PostState.VACANT;
   pendingMessage = none<Opaque<"string">>();
+  pendingOwner = pad(32, "");
   
   sequence.increment(1);
+  adminPubKey = disclose(publicKey(adminSecret(), sequence as Field as Bytes<32>));
   return movedMsg;
 }
 
@@ -111,7 +114,9 @@ export circuit rejectPost(): Opaque<"string"> {
   const formerMsg = pendingMessage.value;
   pendingState = PostState.VACANT;
   pendingMessage = none<Opaque<"string">>();
+  pendingOwner = pad(32, "");
   sequence.increment(1);
+  adminPubKey = disclose(publicKey(adminSecret(), sequence as Field as Bytes<32>));
   
   return formerMsg;
 }
@@ -126,7 +131,9 @@ export circuit unpublish(): Opaque<"string"> {
   const formerMsg = publishedMessage.value;
   publishedState = PostState.VACANT;
   publishedMessage = none<Opaque<"string">>();
+  publishedOwner = pad(32, "");
   sequence.increment(1);
+  adminPubKey = disclose(publicKey(adminSecret(), sequence as Field as Bytes<32>));
   
   return formerMsg;
 }

--- a/contract/src/index.ts
+++ b/contract/src/index.ts
@@ -15,10 +15,10 @@
 
 import { CompiledContract } from "@midnight-ntwrk/compact-js";
 export * from "./managed/bboard/contract/index.js";
-export * from "./witnesses";
+export * from "./witnesses.js";
 
 import * as CompiledBBoardContract from "./managed/bboard/contract/index.js";
-import * as Witnesses from "./witnesses";
+import * as Witnesses from "./witnesses.js";
 
 export const CompiledBBoardContractContract = CompiledContract.make<
   CompiledBBoardContract.Contract<Witnesses.BBoardPrivateState>

--- a/contract/src/test/bboard-simulator.ts
+++ b/contract/src/test/bboard-simulator.ts
@@ -34,15 +34,23 @@ import { type BBoardPrivateState, witnesses } from "../witnesses.js";
 export class BBoardSimulator {
   readonly contract: Contract<BBoardPrivateState>;
   circuitContext: CircuitContext<BBoardPrivateState>;
+  private secretKey: Uint8Array;
+  private adminSecret: Uint8Array;
 
-  constructor(secretKey: Uint8Array) {
+  constructor(secretKey: Uint8Array, adminSecret: Uint8Array) {
+    this.secretKey = secretKey;
+    this.adminSecret = adminSecret;
+    
     this.contract = new Contract<BBoardPrivateState>(witnesses);
     const {
       currentPrivateState,
       currentContractState,
       currentZswapLocalState,
     } = this.contract.initialState(
-      createConstructorContext({ secretKey }, "0".repeat(64)),
+      createConstructorContext(
+        { secretKey, adminSecret },
+        "0".repeat(64),
+      ),
     );
     this.circuitContext = {
       currentPrivateState,
@@ -55,14 +63,34 @@ export class BBoardSimulator {
     };
   }
 
-  /***
-   * Switch to a different secret key for a different user
-   *
-   * TODO: is there a nicer abstraction for testing multi-user dApps?
+  /**
+   * Switch to a different agent (different secret key)
    */
-  public switchUser(secretKey: Uint8Array) {
+  public switchToAgent(secretKey: Uint8Array) {
+    this.secretKey = secretKey;
     this.circuitContext.currentPrivateState = {
       secretKey,
+      adminSecret: this.adminSecret,
+    };
+  }
+
+  /**
+   * Switch to admin context (needed for admin operations)
+   */
+  public switchToAdmin() {
+    this.circuitContext.currentPrivateState = {
+      secretKey: this.secretKey,
+      adminSecret: this.adminSecret,
+    };
+  }
+
+  /**
+   * Switch to agent context (resets to current agent)
+   */
+  public switchToAgentMode() {
+    this.circuitContext.currentPrivateState = {
+      secretKey: this.secretKey,
+      adminSecret: this.adminSecret,
     };
   }
 
@@ -74,23 +102,66 @@ export class BBoardSimulator {
     return this.circuitContext.currentPrivateState;
   }
 
-  public post(message: string): Ledger {
-    // Update the current context to be the result of executing the circuit.
-    this.circuitContext = this.contract.impureCircuits.post(
+  /**
+   * Agent submits a post to the pending board
+   */
+  public submitPost(message: string): Ledger {
+    this.circuitContext = this.contract.impureCircuits.submitPost(
       this.circuitContext,
       message,
     ).context;
     return ledger(this.circuitContext.currentQueryContext.state);
   }
 
-  public takeDown(): Ledger {
-    this.circuitContext = this.contract.impureCircuits.takeDown(
+  /**
+   * Agent withdraws their own pending post
+   */
+  public withdrawPending(): string {
+    const result = this.contract.impureCircuits.withdrawPending(
       this.circuitContext,
-    ).context;
-    return ledger(this.circuitContext.currentQueryContext.state);
+    );
+    this.circuitContext = result.context;
+    // The result is the message that was withdrawn
+    return result.result;
   }
 
-  public publicKey(): Uint8Array {
+  /**
+   * Admin approves a pending post and moves it to published
+   */
+  public approvePost(): string {
+    const result = this.contract.impureCircuits.approvePost(
+      this.circuitContext,
+    );
+    this.circuitContext = result.context;
+    return result.result;
+  }
+
+  /**
+   * Admin rejects a pending post
+   */
+  public rejectPost(): string {
+    const result = this.contract.impureCircuits.rejectPost(
+      this.circuitContext,
+    );
+    this.circuitContext = result.context;
+    return result.result;
+  }
+
+  /**
+   * Admin unpublishes a post (removes it from published board)
+   */
+  public unpublish(): string {
+    const result = this.contract.impureCircuits.unpublish(
+      this.circuitContext,
+    );
+    this.circuitContext = result.context;
+    return result.result;
+  }
+
+  /**
+   * Compute the public key for the current agent
+   */
+  public agentPublicKey(): Uint8Array {
     const sequence = convertFieldToBytes(
       32,
       this.getLedger().sequence,
@@ -98,7 +169,23 @@ export class BBoardSimulator {
     );
     return this.contract.circuits.publicKey(
       this.circuitContext,
-      this.getPrivateState().secretKey,
+      this.secretKey,
+      sequence,
+    ).result;
+  }
+
+  /**
+   * Get the admin's public key
+   */
+  public adminPublicKey(): Uint8Array {
+    const sequence = convertFieldToBytes(
+      32,
+      this.getLedger().sequence,
+      "bboard-simulator.ts",
+    );
+    return this.contract.circuits.publicKey(
+      this.circuitContext,
+      this.adminSecret,
       sequence,
     ).result;
   }

--- a/contract/src/test/bboard-simulator.ts
+++ b/contract/src/test/bboard-simulator.ts
@@ -40,17 +40,14 @@ export class BBoardSimulator {
   constructor(secretKey: Uint8Array, adminSecret: Uint8Array) {
     this.secretKey = secretKey;
     this.adminSecret = adminSecret;
-    
+
     this.contract = new Contract<BBoardPrivateState>(witnesses);
     const {
       currentPrivateState,
       currentContractState,
       currentZswapLocalState,
     } = this.contract.initialState(
-      createConstructorContext(
-        { secretKey, adminSecret },
-        "0".repeat(64),
-      ),
+      createConstructorContext({ secretKey, adminSecret }, "0".repeat(64)),
     );
     this.circuitContext = {
       currentPrivateState,
@@ -140,9 +137,7 @@ export class BBoardSimulator {
    * Admin rejects a pending post
    */
   public rejectPost(): string {
-    const result = this.contract.impureCircuits.rejectPost(
-      this.circuitContext,
-    );
+    const result = this.contract.impureCircuits.rejectPost(this.circuitContext);
     this.circuitContext = result.context;
     return result.result;
   }
@@ -151,9 +146,7 @@ export class BBoardSimulator {
    * Admin unpublishes a post (removes it from published board)
    */
   public unpublish(): string {
-    const result = this.contract.impureCircuits.unpublish(
-      this.circuitContext,
-    );
+    const result = this.contract.impureCircuits.unpublish(this.circuitContext);
     this.circuitContext = result.context;
     return result.result;
   }

--- a/contract/src/test/bboard-simulator.ts
+++ b/contract/src/test/bboard-simulator.ts
@@ -36,6 +36,7 @@ export class BBoardSimulator {
   circuitContext: CircuitContext<BBoardPrivateState>;
   private secretKey: Uint8Array;
   private adminSecret: Uint8Array;
+  private readonly noAdminSecret = new Uint8Array(32);
 
   constructor(secretKey: Uint8Array, adminSecret: Uint8Array) {
     this.secretKey = secretKey;
@@ -58,6 +59,7 @@ export class BBoardSimulator {
         sampleContractAddress(),
       ),
     };
+    this.switchToAgentMode();
   }
 
   /**
@@ -67,7 +69,7 @@ export class BBoardSimulator {
     this.secretKey = secretKey;
     this.circuitContext.currentPrivateState = {
       secretKey,
-      adminSecret: this.adminSecret,
+      adminSecret: this.noAdminSecret,
     };
   }
 
@@ -87,7 +89,7 @@ export class BBoardSimulator {
   public switchToAgentMode() {
     this.circuitContext.currentPrivateState = {
       secretKey: this.secretKey,
-      adminSecret: this.adminSecret,
+      adminSecret: this.noAdminSecret,
     };
   }
 

--- a/contract/src/test/bboard.test.ts
+++ b/contract/src/test/bboard.test.ts
@@ -141,7 +141,7 @@ describe("Extended BBoard Contract - Admin Approval Workflow", () => {
 
       sim.submitPost("Post");
       // Don't switch to admin - stay as agent
-      
+
       expect(() => {
         sim.approvePost();
       }).toThrow("Only admin can approve posts");
@@ -356,10 +356,10 @@ describe("Extended BBoard Contract - Admin Approval Workflow", () => {
       sim.approvePost();
 
       const ledger = sim.getLedger();
-      
+
       // Agent's public key is stored
       expect(ledger.publishedOwner).toEqual(sim.agentPublicKey());
-      
+
       // But we don't store admin's identity
       // Admin proves authority via secret without revealing it
     });

--- a/contract/src/test/bboard.test.ts
+++ b/contract/src/test/bboard.test.ts
@@ -13,6 +13,8 @@ import { PostState } from "../managed/bboard/contract/index.js";
 
 setNetworkId("undeployed" as NetworkId);
 
+const EMPTY_OWNER = new Uint8Array(32);
+
 describe("Extended BBoard Contract - Admin Approval Workflow", () => {
   const adminSecret = randomBytes(32);
 
@@ -77,6 +79,7 @@ describe("Extended BBoard Contract - Admin Approval Workflow", () => {
       expect(withdrawn).toEqual(message);
       expect(ledger.pendingState).toEqual(PostState.VACANT);
       expect(ledger.pendingMessage.is_some).toEqual(false);
+      expect(ledger.pendingOwner).toEqual(EMPTY_OWNER);
     });
 
     it("prevents withdrawing from an empty pending board", () => {
@@ -117,6 +120,7 @@ describe("Extended BBoard Contract - Admin Approval Workflow", () => {
 
       expect(approved).toEqual(message);
       expect(ledger.pendingState).toEqual(PostState.VACANT);
+      expect(ledger.pendingOwner).toEqual(EMPTY_OWNER);
       expect(ledger.publishedState).toEqual(PostState.PUBLISHED);
       expect(ledger.publishedMessage.is_some).toEqual(true);
       expect(ledger.publishedMessage.value).toEqual(message);
@@ -172,6 +176,7 @@ describe("Extended BBoard Contract - Admin Approval Workflow", () => {
       expect(rejected).toEqual(message);
       expect(ledger.pendingState).toEqual(PostState.VACANT);
       expect(ledger.pendingMessage.is_some).toEqual(false);
+      expect(ledger.pendingOwner).toEqual(EMPTY_OWNER);
     });
 
     it("prevents non-admin from rejecting posts", () => {
@@ -212,6 +217,7 @@ describe("Extended BBoard Contract - Admin Approval Workflow", () => {
       expect(unpublished).toEqual(message);
       expect(ledger.publishedState).toEqual(PostState.VACANT);
       expect(ledger.publishedMessage.is_some).toEqual(false);
+      expect(ledger.publishedOwner).toEqual(EMPTY_OWNER);
     });
 
     it("prevents non-admin from unpublishing", () => {
@@ -263,6 +269,7 @@ describe("Extended BBoard Contract - Admin Approval Workflow", () => {
       sim.unpublish();
       ledger = sim.getLedger();
       expect(ledger.publishedState).toEqual(PostState.VACANT);
+      expect(ledger.publishedOwner).toEqual(EMPTY_OWNER);
     });
 
     it("handles workflow: submit -> reject -> submit again", () => {
@@ -350,6 +357,7 @@ describe("Extended BBoard Contract - Admin Approval Workflow", () => {
     it("admin identity is proven but not revealed in approved posts", () => {
       const agentSecret = randomBytes(32);
       const sim = new BBoardSimulator(agentSecret, adminSecret);
+      const agentPubKey = sim.agentPublicKey();
 
       sim.submitPost("Test message");
       sim.switchToAdmin();
@@ -358,7 +366,7 @@ describe("Extended BBoard Contract - Admin Approval Workflow", () => {
       const ledger = sim.getLedger();
 
       // Agent's public key is stored
-      expect(ledger.publishedOwner).toEqual(sim.agentPublicKey());
+      expect(ledger.publishedOwner).toEqual(agentPubKey);
 
       // But we don't store admin's identity
       // Admin proves authority via secret without revealing it

--- a/contract/src/test/bboard.test.ts
+++ b/contract/src/test/bboard.test.ts
@@ -1,17 +1,6 @@
 // This file is part of midnightntwrk/example-bboard.
 // Copyright (C) 2025 Midnight Foundation
 // SPDX-License-Identifier: Apache-2.0
-// Licensed under the Apache License, Version 2.0 (the "License");
-// You may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 import { BBoardSimulator } from "./bboard-simulator.js";
 import {
@@ -20,130 +9,359 @@ import {
 } from "@midnight-ntwrk/midnight-js-network-id";
 import { describe, it, expect } from "vitest";
 import { randomBytes } from "./utils.js";
-import { State } from "../managed/bboard/contract/index.js";
+import { PostState } from "../managed/bboard/contract/index.js";
 
 setNetworkId("undeployed" as NetworkId);
 
-describe("BBoard smart contract", () => {
-  it("generates initial ledger state deterministically", () => {
-    const key = randomBytes(32);
-    const simulator0 = new BBoardSimulator(key);
-    const simulator1 = new BBoardSimulator(key);
-    expect(simulator0.getLedger()).toEqual(simulator1.getLedger());
+describe("Extended BBoard Contract - Admin Approval Workflow", () => {
+  const adminSecret = randomBytes(32);
+
+  it("initializes with both boards in VACANT state", () => {
+    const agentSecret = randomBytes(32);
+    const sim = new BBoardSimulator(agentSecret, adminSecret);
+    const ledger = sim.getLedger();
+
+    expect(ledger.pendingState).toEqual(PostState.VACANT);
+    expect(ledger.publishedState).toEqual(PostState.VACANT);
+    expect(ledger.pendingMessage.is_some).toEqual(false);
+    expect(ledger.publishedMessage.is_some).toEqual(false);
   });
 
-  it("properly initializes ledger state and private state", () => {
-    const key = randomBytes(32);
-    const simulator = new BBoardSimulator(key);
-    const initialLedgerState = simulator.getLedger();
-    expect(initialLedgerState.sequence).toEqual(1n);
-    expect(initialLedgerState.message.is_some).toEqual(false);
-    expect(initialLedgerState.message.value).toEqual("");
-    expect(initialLedgerState.owner).toEqual(new Uint8Array(32));
-    expect(initialLedgerState.state).toEqual(State.VACANT);
-    const initialPrivateState = simulator.getPrivateState();
-    expect(initialPrivateState).toEqual({ secretKey: key });
+  describe("Agent Posting (submitPost)", () => {
+    it("allows an agent to submit a post to the pending board", () => {
+      const agentSecret = randomBytes(32);
+      const sim = new BBoardSimulator(agentSecret, adminSecret);
+
+      const message = "Hello from agent 1";
+      sim.submitPost(message);
+      const ledger = sim.getLedger();
+
+      expect(ledger.pendingState).toEqual(PostState.PENDING);
+      expect(ledger.pendingMessage.is_some).toEqual(true);
+      expect(ledger.pendingMessage.value).toEqual(message);
+      expect(ledger.pendingOwner).toEqual(sim.agentPublicKey());
+    });
+
+    it("prevents posting when pending board is occupied", () => {
+      const agentSecret = randomBytes(32);
+      const sim = new BBoardSimulator(agentSecret, adminSecret);
+
+      sim.submitPost("First post");
+      expect(() => {
+        sim.submitPost("Second post");
+      }).toThrow("Pending board is occupied");
+    });
+
+    it("stores the agent's public key as owner", () => {
+      const agentSecret = randomBytes(32);
+      const sim = new BBoardSimulator(agentSecret, adminSecret);
+      const expectedOwner = sim.agentPublicKey();
+
+      sim.submitPost("Test message");
+      const ledger = sim.getLedger();
+
+      expect(ledger.pendingOwner).toEqual(expectedOwner);
+    });
   });
 
-  it("lets you set a message", () => {
-    const simulator = new BBoardSimulator(randomBytes(32));
-    const initialPrivateState = simulator.getPrivateState();
-    const message =
-      "Szeth-son-son-Vallano, Truthless of Shinovar, wore white on the day he was to kill a king";
-    simulator.post(message);
-    // the private ledger state shouldn't change
-    expect(initialPrivateState).toEqual(simulator.getPrivateState());
-    // And all the correct things should have been updated in the public ledger state
-    const ledgerState = simulator.getLedger();
-    expect(ledgerState.sequence).toEqual(1n);
-    expect(ledgerState.message.is_some).toEqual(true);
-    expect(ledgerState.message.value).toEqual(message);
-    expect(ledgerState.owner).toEqual(simulator.publicKey());
-    expect(ledgerState.state).toEqual(State.OCCUPIED);
+  describe("Agent Withdrawal (withdrawPending)", () => {
+    it("allows an agent to withdraw their own pending post", () => {
+      const agentSecret = randomBytes(32);
+      const sim = new BBoardSimulator(agentSecret, adminSecret);
+      const message = "Post to withdraw";
+
+      sim.submitPost(message);
+      const withdrawn = sim.withdrawPending();
+      const ledger = sim.getLedger();
+
+      expect(withdrawn).toEqual(message);
+      expect(ledger.pendingState).toEqual(PostState.VACANT);
+      expect(ledger.pendingMessage.is_some).toEqual(false);
+    });
+
+    it("prevents withdrawing from an empty pending board", () => {
+      const agentSecret = randomBytes(32);
+      const sim = new BBoardSimulator(agentSecret, adminSecret);
+
+      expect(() => {
+        sim.withdrawPending();
+      }).toThrow("No pending post to withdraw");
+    });
+
+    it("prevents an agent from withdrawing another agent's post", () => {
+      const agent1Secret = randomBytes(32);
+      const agent2Secret = randomBytes(32);
+      const sim = new BBoardSimulator(agent1Secret, adminSecret);
+
+      sim.submitPost("Agent 1's post");
+
+      // Switch to agent 2
+      sim.switchToAgent(agent2Secret);
+
+      expect(() => {
+        sim.withdrawPending();
+      }).toThrow("Cannot withdraw another agent's post");
+    });
   });
 
-  it("lets you take down a message", () => {
-    const simulator = new BBoardSimulator(randomBytes(32));
-    const initialPrivateState = simulator.getPrivateState();
-    const initialPublicKey = simulator.publicKey();
-    const message =
-      "Prince Raoden of Arelon awoke early that morning, completely unaware that he had been damned for all eternity.";
-    simulator.post(message);
-    simulator.takeDown();
-    // the private ledger state shouldn't change
-    expect(initialPrivateState).toEqual(simulator.getPrivateState());
-    // And all the correct things should have been updated in the public ledger state
-    const ledgerState = simulator.getLedger();
-    expect(ledgerState.sequence).toEqual(2n);
-    expect(ledgerState.message.is_some).toEqual(false);
-    expect(ledgerState.message.value).toEqual("");
-    // Technically the circuit doesn't clear the previous owner
-    expect(ledgerState.owner).toEqual(initialPublicKey);
-    expect(ledgerState.state).toEqual(State.VACANT);
+  describe("Admin Approval (approvePost)", () => {
+    it("allows admin to approve a pending post", () => {
+      const agentSecret = randomBytes(32);
+      const sim = new BBoardSimulator(agentSecret, adminSecret);
+      const message = "Post to approve";
+
+      sim.submitPost(message);
+      sim.switchToAdmin();
+      const approved = sim.approvePost();
+      const ledger = sim.getLedger();
+
+      expect(approved).toEqual(message);
+      expect(ledger.pendingState).toEqual(PostState.VACANT);
+      expect(ledger.publishedState).toEqual(PostState.PUBLISHED);
+      expect(ledger.publishedMessage.is_some).toEqual(true);
+      expect(ledger.publishedMessage.value).toEqual(message);
+    });
+
+    it("transfers owner information to published board", () => {
+      const agentSecret = randomBytes(32);
+      const sim = new BBoardSimulator(agentSecret, adminSecret);
+      const agentPubKey = sim.agentPublicKey();
+
+      sim.submitPost("Test");
+      sim.switchToAdmin();
+      sim.approvePost();
+      const ledger = sim.getLedger();
+
+      expect(ledger.publishedOwner).toEqual(agentPubKey);
+    });
+
+    it("prevents non-admin from approving posts", () => {
+      const agentSecret = randomBytes(32);
+      const sim = new BBoardSimulator(agentSecret, adminSecret);
+
+      sim.submitPost("Post");
+      // Don't switch to admin - stay as agent
+      
+      expect(() => {
+        sim.approvePost();
+      }).toThrow("Only admin can approve posts");
+    });
+
+    it("prevents approving when no pending post exists", () => {
+      const agentSecret = randomBytes(32);
+      const sim = new BBoardSimulator(agentSecret, adminSecret);
+
+      sim.switchToAdmin();
+      expect(() => {
+        sim.approvePost();
+      }).toThrow("No pending post to approve");
+    });
   });
 
-  it("lets you post another message after taking down the first", () => {
-    const simulator = new BBoardSimulator(randomBytes(32));
-    const initialPrivateState = simulator.getPrivateState();
-    simulator.post("Life before Death.");
-    simulator.takeDown();
-    const message = "Strength before Weakness.";
-    simulator.post(message);
-    // the private ledger state shouldn't change
-    expect(initialPrivateState).toEqual(simulator.getPrivateState());
-    // And all the correct things should have been updated in the public ledger state
-    const ledgerState = simulator.getLedger();
-    expect(ledgerState.sequence).toEqual(2n);
-    expect(ledgerState.message.is_some).toEqual(true);
-    expect(ledgerState.message.value).toEqual(message);
-    expect(ledgerState.owner).toEqual(simulator.publicKey());
-    expect(ledgerState.state).toEqual(State.OCCUPIED);
+  describe("Admin Rejection (rejectPost)", () => {
+    it("allows admin to reject a pending post", () => {
+      const agentSecret = randomBytes(32);
+      const sim = new BBoardSimulator(agentSecret, adminSecret);
+      const message = "Post to reject";
+
+      sim.submitPost(message);
+      sim.switchToAdmin();
+      const rejected = sim.rejectPost();
+      const ledger = sim.getLedger();
+
+      expect(rejected).toEqual(message);
+      expect(ledger.pendingState).toEqual(PostState.VACANT);
+      expect(ledger.pendingMessage.is_some).toEqual(false);
+    });
+
+    it("prevents non-admin from rejecting posts", () => {
+      const agentSecret = randomBytes(32);
+      const sim = new BBoardSimulator(agentSecret, adminSecret);
+
+      sim.submitPost("Post");
+      // Stay as agent
+
+      expect(() => {
+        sim.rejectPost();
+      }).toThrow("Only admin can reject posts");
+    });
+
+    it("prevents rejecting when no pending post exists", () => {
+      const agentSecret = randomBytes(32);
+      const sim = new BBoardSimulator(agentSecret, adminSecret);
+
+      sim.switchToAdmin();
+      expect(() => {
+        sim.rejectPost();
+      }).toThrow("No pending post to reject");
+    });
   });
 
-  it("lets a different user post a message after taking down the first", () => {
-    const simulator = new BBoardSimulator(randomBytes(32));
-    simulator.post("Remember, the past need not become our future as well.");
-    simulator.takeDown();
-    simulator.switchUser(randomBytes(32));
-    const message = "Joy was more than just an absence of discomfort.";
-    simulator.post(message);
-    const ledgerState = simulator.getLedger();
-    expect(ledgerState.sequence).toEqual(2n);
-    expect(ledgerState.message.is_some).toEqual(true);
-    expect(ledgerState.message.value).toEqual(message);
-    expect(ledgerState.owner).toEqual(simulator.publicKey());
-    expect(ledgerState.state).toEqual(State.OCCUPIED);
+  describe("Admin Unpublish (unpublish)", () => {
+    it("allows admin to remove a published post", () => {
+      const agentSecret = randomBytes(32);
+      const sim = new BBoardSimulator(agentSecret, adminSecret);
+      const message = "Post to unpublish";
+
+      sim.submitPost(message);
+      sim.switchToAdmin();
+      sim.approvePost();
+      const unpublished = sim.unpublish();
+      const ledger = sim.getLedger();
+
+      expect(unpublished).toEqual(message);
+      expect(ledger.publishedState).toEqual(PostState.VACANT);
+      expect(ledger.publishedMessage.is_some).toEqual(false);
+    });
+
+    it("prevents non-admin from unpublishing", () => {
+      const agentSecret = randomBytes(32);
+      const sim = new BBoardSimulator(agentSecret, adminSecret);
+
+      sim.submitPost("Post");
+      sim.switchToAdmin();
+      sim.approvePost();
+
+      // Switch back to agent
+      sim.switchToAgent(agentSecret);
+
+      expect(() => {
+        sim.unpublish();
+      }).toThrow("Only admin can unpublish posts");
+    });
+
+    it("prevents unpublishing when no published post exists", () => {
+      const agentSecret = randomBytes(32);
+      const sim = new BBoardSimulator(agentSecret, adminSecret);
+
+      sim.switchToAdmin();
+      expect(() => {
+        sim.unpublish();
+      }).toThrow("No published post to remove");
+    });
   });
 
-  it("doesn't let the same user post twice", () => {
-    const simulator = new BBoardSimulator(randomBytes(32));
-    simulator.post(
-      "My name is Stephen Leeds, and I am perfectly sane. My hallucinations, however, are all quite mad.",
-    );
-    expect(() =>
-      simulator.post(
-        "You should know by now that I've already had greatness. I traded it for mediocrity and some measure of sanity.",
-      ),
-    ).toThrow("failed assert: Attempted to post to an occupied board");
+  describe("Complex Workflow Scenarios", () => {
+    it("handles full workflow: submit -> approve -> unpublish", () => {
+      const agentSecret = randomBytes(32);
+      const sim = new BBoardSimulator(agentSecret, adminSecret);
+      const message = "Complete workflow";
+
+      // Agent submits
+      sim.submitPost(message);
+      let ledger = sim.getLedger();
+      expect(ledger.pendingState).toEqual(PostState.PENDING);
+
+      // Admin approves
+      sim.switchToAdmin();
+      sim.approvePost();
+      ledger = sim.getLedger();
+      expect(ledger.publishedState).toEqual(PostState.PUBLISHED);
+      expect(ledger.pendingState).toEqual(PostState.VACANT);
+
+      // Admin unpublishes
+      sim.unpublish();
+      ledger = sim.getLedger();
+      expect(ledger.publishedState).toEqual(PostState.VACANT);
+    });
+
+    it("handles workflow: submit -> reject -> submit again", () => {
+      const agentSecret = randomBytes(32);
+      const sim = new BBoardSimulator(agentSecret, adminSecret);
+
+      // First submission
+      sim.submitPost("First attempt");
+      sim.switchToAdmin();
+      const rejected = sim.rejectPost();
+      expect(rejected).toEqual("First attempt");
+
+      // Now the board should be empty, agent can post again
+      sim.switchToAgent(agentSecret);
+      let ledger = sim.getLedger();
+      expect(ledger.pendingState).toEqual(PostState.VACANT);
+
+      // Second submission
+      sim.submitPost("Second attempt");
+      ledger = sim.getLedger();
+      expect(ledger.pendingMessage.value).toEqual("Second attempt");
+    });
+
+    it("tracks sequence counter through multiple operations", () => {
+      const agentSecret = randomBytes(32);
+      const sim = new BBoardSimulator(agentSecret, adminSecret);
+
+      let ledger = sim.getLedger();
+      const initialSeq = ledger.sequence;
+
+      // Submit and approve
+      sim.submitPost("Post 1");
+      sim.switchToAdmin();
+      sim.approvePost();
+      ledger = sim.getLedger();
+      expect(ledger.sequence > initialSeq).toBe(true);
+
+      // Unpublish
+      const seqAfterApproval = ledger.sequence;
+      sim.unpublish();
+      ledger = sim.getLedger();
+      expect(ledger.sequence > seqAfterApproval).toBe(true);
+    });
+
+    it("prevents race conditions: agent cannot post while pending exists", () => {
+      const agent1Secret = randomBytes(32);
+      const agent2Secret = randomBytes(32);
+      const sim = new BBoardSimulator(agent1Secret, adminSecret);
+
+      // Agent 1 posts
+      sim.submitPost("Agent 1 post");
+
+      // Agent 2 cannot post while pending board is occupied
+      sim.switchToAgent(agent2Secret);
+      expect(() => {
+        sim.submitPost("Agent 2 post");
+      }).toThrow("Pending board is occupied");
+    });
   });
 
-  it("doesn't let different users post twice", () => {
-    const simulator = new BBoardSimulator(randomBytes(32));
-    simulator.post("Ash fell from the sky");
-    simulator.switchUser(randomBytes(32));
-    expect(() =>
-      simulator.post("I am, unfortunately, the hero of ages."),
-    ).toThrow("failed assert: Attempted to post to an occupied board");
-  });
+  describe("Privacy Properties", () => {
+    it("correctly derives and stores agent's public key", () => {
+      const agentSecret = randomBytes(32);
+      const sim = new BBoardSimulator(agentSecret, adminSecret);
+      const expectedPubKey = sim.agentPublicKey();
 
-  it("doesn't let users take down someone elses posts", () => {
-    const simulator = new BBoardSimulator(randomBytes(32));
-    simulator.post(
-      "Sometimes a hypocrite is nothing more than a man in the process of changing.",
-    );
-    simulator.switchUser(randomBytes(32));
-    expect(() => simulator.takeDown()).toThrow(
-      "failed assert: Attempted to take down post, but not the current owner",
-    );
+      sim.submitPost("Test");
+      const ledger = sim.getLedger();
+
+      expect(ledger.pendingOwner).toEqual(expectedPubKey);
+    });
+
+    it("messages are disclosed as they should be public", () => {
+      const agentSecret = randomBytes(32);
+      const sim = new BBoardSimulator(agentSecret, adminSecret);
+      const message = "Public message on board";
+
+      sim.submitPost(message);
+      const ledger = sim.getLedger();
+
+      // Messages should be readable in ledger (disclosed)
+      expect(ledger.pendingMessage.value).toEqual(message);
+    });
+
+    it("admin identity is proven but not revealed in approved posts", () => {
+      const agentSecret = randomBytes(32);
+      const sim = new BBoardSimulator(agentSecret, adminSecret);
+
+      sim.submitPost("Test message");
+      sim.switchToAdmin();
+      sim.approvePost();
+
+      const ledger = sim.getLedger();
+      
+      // Agent's public key is stored
+      expect(ledger.publishedOwner).toEqual(sim.agentPublicKey());
+      
+      // But we don't store admin's identity
+      // Admin proves authority via secret without revealing it
+    });
   });
 });

--- a/contract/src/witnesses.ts
+++ b/contract/src/witnesses.ts
@@ -15,54 +15,34 @@
 
 /*
  * This file defines the shape of the bulletin board's private state,
- * as well as the single witness function that accesses it.
+ * as well as the witness functions for the contract.
+ *
+ * The bulletin board now supports two roles:
+ * - Agents: can submit posts and withdraw pending posts (via secretKey)
+ * - Admin: can approve, reject, and unpublish posts (via adminSecret)
  */
 
 import { Ledger } from "./managed/bboard/contract/index.js";
 import { WitnessContext } from "@midnight-ntwrk/compact-runtime";
 
-/* **********************************************************************
- * The only hidden state needed by the bulletin board contract is
- * the user's secret key.  Some of the library code and
- * compiler-generated code is parameterized by the type of our
- * private state, so we define a type for it and a function to
- * make an object of that type.
- */
-
 export type BBoardPrivateState = {
   readonly secretKey: Uint8Array;
+  readonly adminSecret: Uint8Array;
 };
 
-export const createBBoardPrivateState = (secretKey: Uint8Array) => ({
+export const createBBoardPrivateState = (
+  secretKey: Uint8Array,
+  adminSecret: Uint8Array,
+) => ({
   secretKey,
+  adminSecret,
 });
 
-/* **********************************************************************
- * The witnesses object for the bulletin board contract is an object
- * with a field for each witness function, mapping the name of the function
- * to its implementation.
+/**
+ * Witnesses provide access to the contract's private state.
  *
- * The implementation of each function always takes as its first argument
- * a value of type WitnessContext<L, PS>, where L is the ledger object type
- * that corresponds to the ledger declaration in the Compact code, and PS
- *  is the private state type, like BBoardPrivateState defined above.
- *
- * A WitnessContext has three
- * fields:
- *  - ledger: T
- *  - privateState: PS
- *  - contractAddress: string
- *
- * The other arguments (after the first) to each witness function
- * correspond to the ones declared in Compact for the witness function.
- * The function's return value is a tuple of the new private state and
- * the declared return value.  In this case, that's a BBoardPrivateState
- * and a Uint8Array (because the contract declared a return value of Bytes[32],
- * and that's a Uint8Array in TypeScript).
- *
- * The localSecretKey witness does not need the ledger or contractAddress
- * from the WitnessContext, so it uses the parameter notation that puts
- * only the binding for the privateState in scope.
+ * - localSecretKey: Returns the agent's secret key for deriving ownership proofs
+ * - adminSecret: Returns the admin's secret key for authorization checks
  */
 export const witnesses = {
   localSecretKey: ({
@@ -71,4 +51,11 @@ export const witnesses = {
     BBoardPrivateState,
     Uint8Array,
   ] => [privateState, privateState.secretKey],
+
+  adminSecret: ({
+    privateState,
+  }: WitnessContext<Ledger, BBoardPrivateState>): [
+    BBoardPrivateState,
+    Uint8Array,
+  ] => [privateState, privateState.adminSecret],
 };

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,0 +1,161 @@
+# Bulletin Board MCP Server
+
+This package exposes the bulletin board contract as an MCP server over `stdio`.
+
+It can also run in HTTP mode for environments where network access is easier than child-process stdio wiring.
+
+The proof server is consumed locally by the MCP server. Agents do not need to call it directly.
+
+Sensitive admin data policy:
+
+- the server never returns `adminSecret`
+- the server never returns `adminPubKey`
+
+## What it gives you
+
+- MCP `tools` for session creation, wallet preparation, board deployment/join, reads, and mutations
+- MCP `resources` with agent-facing instructions
+- A reusable session pattern that separates wallet credentials from contract witness credentials
+
+Current tools:
+
+- `bboard_create_session`
+- `bboard_get_session`
+- `bboard_set_admin_secret`
+- `bboard_wait_for_wallet_ready`
+- `bboard_deploy_board`
+- `bboard_join_board`
+- `bboard_get_board_state`
+- `bboard_submit_post`
+- `bboard_withdraw_pending`
+- `bboard_approve_pending`
+- `bboard_reject_pending`
+- `bboard_unpublish_published`
+- `bboard_close_session`
+
+## Run locally
+
+From the repo root:
+
+```bash
+cd mcp-server
+npm run build
+npm run start
+```
+
+For development:
+
+```bash
+cd mcp-server
+npm run start:dev
+```
+
+## HTTP Mode
+
+Start the server in HTTP mode:
+
+```bash
+cd mcp-server
+npm run build
+npm run start:http
+```
+
+Default bind:
+
+```text
+http://127.0.0.1:8787
+```
+
+Endpoints:
+
+- `GET /health`
+- `POST /mcp`
+
+Example health check:
+
+```bash
+curl http://127.0.0.1:8787/health
+```
+
+Example JSON-RPC call:
+
+```bash
+curl -X POST http://127.0.0.1:8787/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+Notes:
+
+- HTTP mode currently uses request/response JSON-RPC over HTTP.
+- It is practical for local agents and reverse proxies.
+- If you need HTTPS, place it behind a reverse proxy such as Caddy, Nginx, or Traefik.
+
+## Proof Server Handling
+
+By default, the MCP server assumes a local proof server at:
+
+```text
+http://127.0.0.1:6300
+```
+
+You can override it with:
+
+```bash
+BBOARD_PROOF_SERVER_URL=http://127.0.0.1:6300
+```
+
+You can also ask the MCP server to start the local Docker proof server automatically:
+
+```bash
+cd mcp-server
+npm run build
+npm run start:http:auto-proof
+```
+
+Equivalent manual flags:
+
+```bash
+node --experimental-specifier-resolution=node ./dist/mcp-server/src/index.js \
+  --http \
+  --host 127.0.0.1 \
+  --port 8787 \
+  --start-proof-server
+```
+
+Optional shutdown of the Docker proof server when the MCP exits:
+
+```bash
+node --experimental-specifier-resolution=node ./dist/mcp-server/src/index.js \
+  --http \
+  --start-proof-server \
+  --stop-proof-server-on-exit
+```
+
+## Example client config
+
+Point your MCP client at:
+
+```bash
+node --experimental-specifier-resolution=node /mnt/linuxdata/example-bboard/mcp-server/dist/mcp-server/src/index.js
+```
+
+If your client can run workspace scripts directly, this also works:
+
+```bash
+npm --workspace /mnt/linuxdata/example-bboard/mcp-server run start
+```
+
+`stdio` remains the default mode.
+
+## Template notes
+
+The generic pattern lives in:
+
+- `src/stdio.ts`: stdio transport with MCP framing
+- `src/transports.ts`: stdio transport
+- `src/index.ts`: transport selection and HTTP server bootstrap
+- `src/server.ts`: MCP method handling and tool/resource registration
+- `src/session-manager.ts`: app-specific wallet, session, and tool logic
+
+For a similar project, you will usually replace only `session-manager.ts` plus the tool/resource definitions in `server.ts`.

--- a/mcp-server/docs/AGENT_WORKFLOW.md
+++ b/mcp-server/docs/AGENT_WORKFLOW.md
@@ -1,0 +1,31 @@
+# Agent Workflow
+
+Use this server as a stateful wrapper around the bulletin board contract.
+
+## Recommended sequence
+
+1. Call `bboard_create_session`.
+2. Persist the returned `sessionId`, `walletSeed`, `agentSecretKey`, and later the `contractAddress`.
+3. Call `bboard_wait_for_wallet_ready` before sending transactions.
+4. Call `bboard_deploy_board` to create a new board, or `bboard_join_board` to reuse an existing one.
+5. Call `bboard_get_board_state` before taking action when context matters.
+6. Use `bboard_submit_post`, `bboard_withdraw_pending`, `bboard_approve_pending`, `bboard_reject_pending`, or `bboard_unpublish_published` as needed.
+7. Call `bboard_close_session` when done.
+
+## Identity model
+
+One MCP session maps to one agent identity.
+
+- `walletSeed` pays fees and signs Midnight wallet transactions.
+- `agentSecretKey` proves ownership of pending posts.
+- `adminSecret` authorizes moderation actions, but it is write-only input and is never returned by the server.
+
+If you lose `walletSeed` or `agentSecretKey`, you lose the ability to recreate the same identity in a new session.
+
+## Safe operating rules
+
+- Treat returned secrets as durable credentials and store them outside the server.
+- Treat admin secret as external write-only input. Reuse the same admin secret for the same board if you need admin actions later, but do not expect the MCP server to reveal it.
+- Use a different `agentSecretKey` for different agents unless you intentionally want them to share ownership.
+- Wait for wallet readiness before expecting transactions to succeed.
+- On `preview` and `preprod`, the proof server must be available through the local Docker-backed environment.

--- a/mcp-server/docs/CREDENTIAL_MODEL.md
+++ b/mcp-server/docs/CREDENTIAL_MODEL.md
@@ -1,0 +1,37 @@
+# Credential Model
+
+This MCP server makes the credential story explicit so other projects can reuse the same pattern.
+
+## Three credentials matter
+
+### 1. `walletSeed`
+
+This is the Midnight wallet seed used to derive the transaction-signing wallet. It is needed for funding, dust registration, and transaction submission.
+
+### 2. `agentSecretKey`
+
+This is contract private state, not the wallet seed. The contract uses it to derive the public owner key for posts.
+
+### 3. `adminSecret`
+
+This is also contract private state. It is the credential that proves moderation authority for `approve`, `reject`, and `unpublish`.
+
+The MCP server treats it as write-only input:
+
+- it may be provided to `bboard_create_session`, or later through `bboard_set_admin_secret`,
+- it is never returned by `bboard_get_session`,
+- it is never included in board state responses,
+- it is never exposed as an MCP resource.
+
+## Why not derive everything from one seed?
+
+For this repo, the wallet identity and the contract witnesses are distinct concerns:
+
+- the wallet seed funds and submits transactions,
+- the contract secrets control ownership and moderation inside the contract.
+
+Keeping them separate makes the template usable for similar Midnight projects where on-chain witness identity and wallet identity may evolve independently.
+
+## Session persistence
+
+The server keeps a private-state LevelDB per session under `mcp-state/`, but agents should still persist their own reusable credentials themselves. The LevelDB is a convenience cache for the running server, not the canonical identity record for an agent.

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -10,11 +10,12 @@
   "types": "./dist/mcp-server/src/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && tsc --project tsconfig.build.json && cp -Rf ../contract/src/managed ./dist/contract/src/managed",
-    "ci": "npm run typecheck && npm run build",
+    "ci": "npm run typecheck && npm run build && npm run test",
     "start": "node --experimental-specifier-resolution=node ./dist/mcp-server/src/index.js",
     "start:http:auto-proof": "node --experimental-specifier-resolution=node ./dist/mcp-server/src/index.js --http --host 127.0.0.1 --port 8787 --start-proof-server",
     "start:http": "node --experimental-specifier-resolution=node ./dist/mcp-server/src/index.js --http --host 127.0.0.1 --port 8787",
     "start:dev": "node --experimental-specifier-resolution=node --loader ts-node/esm src/index.ts",
+    "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   }
 }

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@midnight-ntwrk/bboard-mcp-server",
+  "version": "0.1.0",
+  "author": "IOG",
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "main": "./dist/mcp-server/src/index.js",
+  "module": "./dist/mcp-server/src/index.js",
+  "types": "./dist/mcp-server/src/index.d.ts",
+  "scripts": {
+    "build": "rm -rf dist && tsc --project tsconfig.build.json && cp -Rf ../contract/src/managed ./dist/contract/src/managed",
+    "ci": "npm run typecheck && npm run build",
+    "start": "node --experimental-specifier-resolution=node ./dist/mcp-server/src/index.js",
+    "start:http:auto-proof": "node --experimental-specifier-resolution=node ./dist/mcp-server/src/index.js --http --host 127.0.0.1 --port 8787 --start-proof-server",
+    "start:http": "node --experimental-specifier-resolution=node ./dist/mcp-server/src/index.js --http --host 127.0.0.1 --port 8787",
+    "start:dev": "node --experimental-specifier-resolution=node --loader ts-node/esm src/index.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  }
+}

--- a/mcp-server/src/http-server.test.ts
+++ b/mcp-server/src/http-server.test.ts
@@ -1,0 +1,136 @@
+import http from 'node:http';
+import { Readable } from 'node:stream';
+import { describe, expect, it, vi } from 'vitest';
+import { createHttpHandler } from './http-server.js';
+import { JSON_RPC_VERSION, type JsonRpcMessage } from './protocol.js';
+import { type McpConnection } from './transports.js';
+
+class MockRequest extends Readable {
+  method?: string;
+  url?: string;
+  headers: http.IncomingHttpHeaders;
+  socket: { remoteAddress?: string };
+
+  constructor(method: string, url: string, body = '', headers: http.IncomingHttpHeaders = {}) {
+    super();
+    this.method = method;
+    this.url = url;
+    this.headers = headers;
+    this.socket = { remoteAddress: '127.0.0.1' };
+    this.push(body);
+    this.push(null);
+  }
+
+  override _read(): void {}
+}
+
+class MockResponse {
+  statusCode?: number;
+  headers?: Record<string, string>;
+  body = '';
+
+  writeHead(statusCode: number, headers: Record<string, string>) {
+    this.statusCode = statusCode;
+    this.headers = headers;
+    return this;
+  }
+
+  end(body?: string) {
+    this.body = body ?? '';
+    return this;
+  }
+}
+
+const defaultOnMessage = async (connection: McpConnection): Promise<void> => {
+  connection.send({
+    jsonrpc: JSON_RPC_VERSION,
+    id: 1,
+    result: { ok: true },
+  } as JsonRpcMessage);
+};
+
+const createHandler = (onMessage: (connection: McpConnection, message: JsonRpcMessage) => Promise<void> = defaultOnMessage) =>
+  createHttpHandler({
+    host: '127.0.0.1',
+    port: 8787,
+    log: vi.fn(),
+    onMessage,
+  });
+
+describe('createHttpHandler', () => {
+  it('serves health checks', async () => {
+    const handler = createHandler();
+    const response = new MockResponse();
+
+    await handler(new MockRequest('GET', '/health') as unknown as http.IncomingMessage, response as unknown as http.ServerResponse);
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toMatchObject({ ok: true, transport: 'http' });
+  });
+
+  it('accepts POST /mcp requests', async () => {
+    const onMessage = vi.fn(async (connection: McpConnection, message: JsonRpcMessage) => {
+      expect(message).toMatchObject({ method: 'tools/list' });
+      connection.send({ jsonrpc: JSON_RPC_VERSION, id: 1, result: { ok: true } } as JsonRpcMessage);
+    });
+    const handler = createHandler(onMessage);
+    const response = new MockResponse();
+
+    await handler(
+      new MockRequest('POST', '/mcp', '{"jsonrpc":"2.0","id":1,"method":"tools/list"}', {
+        host: '127.0.0.1:8787',
+        'content-type': 'application/json',
+      }) as unknown as http.IncomingMessage,
+      response as unknown as http.ServerResponse,
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toMatchObject({ id: 1, result: { ok: true } });
+  });
+
+  it('accepts POST / and /mcp/ as RPC endpoints', async () => {
+    for (const path of ['/', '/mcp/']) {
+      const handler = createHandler();
+      const response = new MockResponse();
+
+      await handler(
+        new MockRequest('POST', path, '{"jsonrpc":"2.0","id":1,"method":"tools/list"}') as unknown as http.IncomingMessage,
+        response as unknown as http.ServerResponse,
+      );
+
+      expect(response.statusCode).toBe(200);
+      expect(JSON.parse(response.body)).toMatchObject({ id: 1, result: { ok: true } });
+    }
+  });
+
+  it('returns 404 for unknown paths', async () => {
+    const handler = createHandler();
+    const response = new MockResponse();
+
+    await handler(new MockRequest('POST', '/nope', '{}') as unknown as http.IncomingMessage, response as unknown as http.ServerResponse);
+
+    expect(response.statusCode).toBe(404);
+  });
+
+  it('handles preflight requests', async () => {
+    const handler = createHandler();
+    const response = new MockResponse();
+
+    await handler(new MockRequest('OPTIONS', '/mcp') as unknown as http.IncomingMessage, response as unknown as http.ServerResponse);
+
+    expect(response.statusCode).toBe(204);
+  });
+
+  it('returns 400 on invalid JSON bodies', async () => {
+    const handler = createHandler();
+    const response = new MockResponse();
+
+    await handler(new MockRequest('POST', '/mcp', '{bad json') as unknown as http.IncomingMessage, response as unknown as http.ServerResponse);
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.body)).toMatchObject({
+      jsonrpc: JSON_RPC_VERSION,
+      id: null,
+    });
+  });
+});

--- a/mcp-server/src/http-server.ts
+++ b/mcp-server/src/http-server.ts
@@ -1,0 +1,145 @@
+import http from 'node:http';
+import { JSON_RPC_VERSION, type JsonRpcMessage, type JsonRpcResponse, toJsonError } from './protocol.js';
+import { type McpConnection } from './transports.js';
+
+export type HttpServerOptions = {
+  host: string;
+  port: number;
+  log: (message: string, extra?: Record<string, unknown>) => void;
+  onMessage: (connection: McpConnection, message: JsonRpcMessage) => Promise<void>;
+};
+
+const HTTP_ALLOWED_RPC_PATHS = new Set(['/', '/mcp', '/mcp/']);
+
+const getRequestUrl = (request: http.IncomingMessage, host: string, port: number): URL => {
+  const requestHost = request.headers.host ?? `${host}:${port}`;
+  const rawUrl = request.url ?? '/';
+  try {
+    return new URL(rawUrl, `http://${requestHost}`);
+  } catch {
+    return new URL('/', `http://${requestHost}`);
+  }
+};
+
+const isRpcPath = (pathname: string): boolean => HTTP_ALLOWED_RPC_PATHS.has(pathname);
+
+const readRequestBody = async (request: http.IncomingMessage): Promise<string> => {
+  const chunks: Buffer[] = [];
+
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+
+  return Buffer.concat(chunks).toString('utf8');
+};
+
+export const sendHttpJson = (
+  response: http.ServerResponse,
+  statusCode: number,
+  body: JsonRpcResponse | Record<string, unknown>,
+): void => {
+  response.writeHead(statusCode, {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+  });
+  response.end(JSON.stringify(body));
+};
+
+export const createHttpHandler =
+  ({ host, port, log, onMessage }: HttpServerOptions) =>
+  async (request: http.IncomingMessage, response: http.ServerResponse): Promise<void> => {
+    const requestUrl = getRequestUrl(request, host, port);
+    const pathname = requestUrl.pathname;
+
+    log('[mcp-http] request', {
+      method: request.method,
+      url: request.url ?? '/',
+      pathname,
+      origin: request.headers.origin ?? null,
+      userAgent: request.headers['user-agent'] ?? null,
+    });
+
+    if (request.method === 'OPTIONS') {
+      response.writeHead(204, {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers': 'Content-Type',
+        'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+      });
+      response.end();
+      return;
+    }
+
+    if (request.method === 'GET' && pathname === '/health') {
+      sendHttpJson(response, 200, {
+        ok: true,
+        transport: 'http',
+        name: 'example-bboard-mcp-server',
+      });
+      return;
+    }
+
+    if (request.method === 'GET' && pathname === '/') {
+      sendHttpJson(response, 200, {
+        ok: true,
+        message: 'Use POST /mcp for JSON-RPC MCP requests. Use GET /health for health checks.',
+      });
+      return;
+    }
+
+    if (request.method !== 'POST' || !isRpcPath(pathname)) {
+      log('[mcp-http] 404', {
+        method: request.method,
+        url: request.url ?? '/',
+        pathname,
+      });
+      sendHttpJson(response, 404, { ok: false, error: 'Not found' });
+      return;
+    }
+
+    let replied = false;
+    const connection: McpConnection = {
+      id: request.socket.remoteAddress ? `http:${request.socket.remoteAddress}` : 'http',
+      send: (message: JsonRpcMessage) => {
+        replied = true;
+        sendHttpJson(response, 200, message as JsonRpcResponse);
+      },
+    };
+
+    try {
+      const rawBody = await readRequestBody(request);
+      log('[mcp-http] body', { body: rawBody });
+      const message = JSON.parse(rawBody) as JsonRpcMessage;
+      await onMessage(connection, message);
+
+      if (!replied) {
+        response.writeHead(204, {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Headers': 'Content-Type',
+        });
+        response.end();
+      }
+    } catch (error) {
+      log('[mcp-http] error', {
+        message: error instanceof Error ? error.message : 'Unknown error',
+        url: request.url ?? '/',
+      });
+      sendHttpJson(response, 400, {
+        jsonrpc: JSON_RPC_VERSION,
+        id: null,
+        error: toJsonError(error ?? new Error('Invalid request body')),
+      });
+    }
+  };
+
+export const startHttpServer = async (options: HttpServerOptions): Promise<http.Server> => {
+  const server = http.createServer(createHttpHandler(options));
+
+  await new Promise<void>((resolve, reject) => {
+    server.on('error', reject);
+    server.listen(options.port, options.host, () => resolve());
+  });
+
+  return server;
+};

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1,0 +1,257 @@
+import http from 'node:http';
+import { stderr } from 'node:process';
+import { BBoardMcpServer } from './server.js';
+import { JSON_RPC_VERSION, ErrorCodes, type JsonRpcMessage, type JsonRpcResponse, toJsonError } from './protocol.js';
+import { ProofServerManager } from './proof-server-manager.js';
+import { StdioTransport, type McpConnection } from './transports.js';
+
+type LaunchOptions = {
+  transport: 'stdio' | 'http';
+  host: string;
+  port: number;
+  proofServerUrl: string;
+  startProofServer: boolean;
+  stopProofServerOnExit: boolean;
+};
+
+const parseArgs = (): LaunchOptions => {
+  const args = process.argv.slice(2);
+  const options: LaunchOptions = {
+    transport: (process.env.BBOARD_MCP_TRANSPORT as 'stdio' | 'http' | undefined) ?? 'stdio',
+    host: process.env.BBOARD_MCP_HOST ?? '127.0.0.1',
+    port: Number.parseInt(process.env.BBOARD_MCP_PORT ?? '8787', 10),
+    proofServerUrl: process.env.BBOARD_PROOF_SERVER_URL ?? 'http://127.0.0.1:6300',
+    startProofServer:
+      (process.env.BBOARD_MCP_START_PROOF_SERVER ?? '').toLowerCase() === '1' ||
+      (process.env.BBOARD_MCP_START_PROOF_SERVER ?? '').toLowerCase() === 'true',
+    stopProofServerOnExit:
+      (process.env.BBOARD_MCP_STOP_PROOF_SERVER_ON_EXIT ?? '').toLowerCase() === '1' ||
+      (process.env.BBOARD_MCP_STOP_PROOF_SERVER_ON_EXIT ?? '').toLowerCase() === 'true',
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--transport') {
+      const value = args[index + 1];
+      if (value === 'stdio' || value === 'http') {
+        options.transport = value;
+        index += 1;
+      }
+    } else if (arg === '--http') {
+      options.transport = 'http';
+    } else if (arg === '--host') {
+      options.host = args[index + 1] ?? options.host;
+      index += 1;
+    } else if (arg === '--port') {
+      const rawPort = Number.parseInt(args[index + 1] ?? '', 10);
+      if (!Number.isNaN(rawPort)) {
+        options.port = rawPort;
+      }
+      index += 1;
+    } else if (arg === '--proof-server-url') {
+      options.proofServerUrl = args[index + 1] ?? options.proofServerUrl;
+      index += 1;
+    } else if (arg === '--start-proof-server') {
+      options.startProofServer = true;
+    } else if (arg === '--stop-proof-server-on-exit') {
+      options.stopProofServerOnExit = true;
+    }
+  }
+
+  return options;
+};
+
+const options = parseArgs();
+const server =
+  options.transport === 'http'
+    ? new BBoardMcpServer(new StdioTransport(), { requireInitialize: false })
+    : new BBoardMcpServer(new StdioTransport());
+
+let httpServer: http.Server | undefined;
+
+const HTTP_ALLOWED_RPC_PATHS = new Set(['/', '/mcp', '/mcp/']);
+
+const logStderr = (message: string, extra?: Record<string, unknown>): void => {
+  const line = extra ? `${message} ${JSON.stringify(extra)}\n` : `${message}\n`;
+  stderr.write(line);
+};
+
+const proofServerManager = new ProofServerManager({
+  url: options.proofServerUrl,
+  autoStart: options.startProofServer,
+  shutdownOnExit: options.stopProofServerOnExit,
+  stderrLog: logStderr,
+});
+
+process.env.BBOARD_PROOF_SERVER_URL = options.proofServerUrl;
+
+const getRequestUrl = (request: http.IncomingMessage): URL => {
+  const host = request.headers.host ?? `${options.host}:${options.port}`;
+  const rawUrl = request.url ?? '/';
+  try {
+    return new URL(rawUrl, `http://${host}`);
+  } catch {
+    return new URL('/', `http://${host}`);
+  }
+};
+
+const isRpcPath = (pathname: string): boolean => HTTP_ALLOWED_RPC_PATHS.has(pathname);
+
+const readRequestBody = async (request: http.IncomingMessage): Promise<string> => {
+  const chunks: Buffer[] = [];
+
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+
+  return Buffer.concat(chunks).toString('utf8');
+};
+
+const sendHttpJson = (response: http.ServerResponse, statusCode: number, body: JsonRpcResponse | Record<string, unknown>) => {
+  response.writeHead(statusCode, {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+  });
+  response.end(JSON.stringify(body));
+};
+
+const startHttpServer = async (): Promise<void> => {
+  httpServer = http.createServer(async (request, response) => {
+    const requestUrl = getRequestUrl(request);
+    const pathname = requestUrl.pathname;
+
+    logStderr('[mcp-http] request', {
+      method: request.method,
+      url: request.url ?? '/',
+      pathname,
+      origin: request.headers.origin ?? null,
+      userAgent: request.headers['user-agent'] ?? null,
+    });
+
+    if (request.method === 'OPTIONS') {
+      response.writeHead(204, {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers': 'Content-Type',
+        'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+      });
+      response.end();
+      return;
+    }
+
+    if (request.method === 'GET' && pathname === '/health') {
+      sendHttpJson(response, 200, {
+        ok: true,
+        transport: 'http',
+        name: 'example-bboard-mcp-server',
+      });
+      return;
+    }
+
+    if (request.method === 'GET' && pathname === '/') {
+      sendHttpJson(response, 200, {
+        ok: true,
+        message: 'Use POST /mcp for JSON-RPC MCP requests. Use GET /health for health checks.',
+      });
+      return;
+    }
+
+    if (request.method !== 'POST' || !isRpcPath(pathname)) {
+      logStderr('[mcp-http] 404', {
+        method: request.method,
+        url: request.url ?? '/',
+        pathname,
+      });
+      sendHttpJson(response, 404, { ok: false, error: 'Not found' });
+      return;
+    }
+
+    let replied = false;
+    const connection: McpConnection = {
+      id: request.socket.remoteAddress ? `http:${request.socket.remoteAddress}` : 'http',
+      send: (message: JsonRpcMessage) => {
+        replied = true;
+        sendHttpJson(response, 200, message as JsonRpcResponse);
+      },
+    };
+
+    try {
+      const rawBody = await readRequestBody(request);
+      logStderr('[mcp-http] body', { body: rawBody });
+      const message = JSON.parse(rawBody) as JsonRpcMessage;
+      await server.processIncomingMessage(connection, message);
+
+      if (!replied) {
+        response.writeHead(204, {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Headers': 'Content-Type',
+        });
+        response.end();
+      }
+    } catch (error) {
+      logStderr('[mcp-http] error', {
+        message: error instanceof Error ? error.message : 'Unknown error',
+        url: request.url ?? '/',
+      });
+      const fallbackId = 'id' in (error as object) ? undefined : null;
+      sendHttpJson(response, 400, {
+        jsonrpc: JSON_RPC_VERSION,
+        id: fallbackId,
+        error: toJsonError(error ?? new Error(`Invalid request body`)),
+      });
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    httpServer?.on('error', reject);
+    httpServer?.listen(options.port, options.host, () => resolve());
+  });
+};
+
+const shutdown = async () => {
+  if (httpServer) {
+    await new Promise<void>((resolve, reject) => {
+      httpServer?.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+  await server.shutdown();
+  await proofServerManager.shutdown();
+  process.exit(0);
+};
+
+process.on('SIGINT', () => {
+  void shutdown();
+});
+
+process.on('SIGTERM', () => {
+  void shutdown();
+});
+
+if (options.transport === 'http') {
+  logStderr('[mcp] starting', {
+    transport: 'http',
+    host: options.host,
+    port: options.port,
+    proofServerUrl: options.proofServerUrl,
+    startProofServer: options.startProofServer,
+  });
+  await proofServerManager.ensureReady();
+  await startHttpServer();
+} else {
+  logStderr('[mcp] starting', {
+    transport: options.transport,
+    host: null,
+    port: null,
+    proofServerUrl: options.proofServerUrl,
+    startProofServer: options.startProofServer,
+  });
+  await proofServerManager.ensureReady();
+  await server.start();
+}

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1,9 +1,9 @@
 import http from 'node:http';
 import { stderr } from 'node:process';
+import { startHttpServer as startConfiguredHttpServer } from './http-server.js';
 import { BBoardMcpServer } from './server.js';
-import { JSON_RPC_VERSION, ErrorCodes, type JsonRpcMessage, type JsonRpcResponse, toJsonError } from './protocol.js';
 import { ProofServerManager } from './proof-server-manager.js';
-import { StdioTransport, type McpConnection } from './transports.js';
+import { StdioTransport } from './transports.js';
 
 type LaunchOptions = {
   transport: 'stdio' | 'http';
@@ -69,8 +69,6 @@ const server =
 
 let httpServer: http.Server | undefined;
 
-const HTTP_ALLOWED_RPC_PATHS = new Set(['/', '/mcp', '/mcp/']);
-
 const logStderr = (message: string, extra?: Record<string, unknown>): void => {
   const line = extra ? `${message} ${JSON.stringify(extra)}\n` : `${message}\n`;
   stderr.write(line);
@@ -85,127 +83,14 @@ const proofServerManager = new ProofServerManager({
 
 process.env.BBOARD_PROOF_SERVER_URL = options.proofServerUrl;
 
-const getRequestUrl = (request: http.IncomingMessage): URL => {
-  const host = request.headers.host ?? `${options.host}:${options.port}`;
-  const rawUrl = request.url ?? '/';
-  try {
-    return new URL(rawUrl, `http://${host}`);
-  } catch {
-    return new URL('/', `http://${host}`);
-  }
-};
-
-const isRpcPath = (pathname: string): boolean => HTTP_ALLOWED_RPC_PATHS.has(pathname);
-
-const readRequestBody = async (request: http.IncomingMessage): Promise<string> => {
-  const chunks: Buffer[] = [];
-
-  for await (const chunk of request) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-  }
-
-  return Buffer.concat(chunks).toString('utf8');
-};
-
-const sendHttpJson = (response: http.ServerResponse, statusCode: number, body: JsonRpcResponse | Record<string, unknown>) => {
-  response.writeHead(statusCode, {
-    'Content-Type': 'application/json',
-    'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Headers': 'Content-Type',
-    'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
-  });
-  response.end(JSON.stringify(body));
-};
-
 const startHttpServer = async (): Promise<void> => {
-  httpServer = http.createServer(async (request, response) => {
-    const requestUrl = getRequestUrl(request);
-    const pathname = requestUrl.pathname;
-
-    logStderr('[mcp-http] request', {
-      method: request.method,
-      url: request.url ?? '/',
-      pathname,
-      origin: request.headers.origin ?? null,
-      userAgent: request.headers['user-agent'] ?? null,
-    });
-
-    if (request.method === 'OPTIONS') {
-      response.writeHead(204, {
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Headers': 'Content-Type',
-        'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
-      });
-      response.end();
-      return;
-    }
-
-    if (request.method === 'GET' && pathname === '/health') {
-      sendHttpJson(response, 200, {
-        ok: true,
-        transport: 'http',
-        name: 'example-bboard-mcp-server',
-      });
-      return;
-    }
-
-    if (request.method === 'GET' && pathname === '/') {
-      sendHttpJson(response, 200, {
-        ok: true,
-        message: 'Use POST /mcp for JSON-RPC MCP requests. Use GET /health for health checks.',
-      });
-      return;
-    }
-
-    if (request.method !== 'POST' || !isRpcPath(pathname)) {
-      logStderr('[mcp-http] 404', {
-        method: request.method,
-        url: request.url ?? '/',
-        pathname,
-      });
-      sendHttpJson(response, 404, { ok: false, error: 'Not found' });
-      return;
-    }
-
-    let replied = false;
-    const connection: McpConnection = {
-      id: request.socket.remoteAddress ? `http:${request.socket.remoteAddress}` : 'http',
-      send: (message: JsonRpcMessage) => {
-        replied = true;
-        sendHttpJson(response, 200, message as JsonRpcResponse);
-      },
-    };
-
-    try {
-      const rawBody = await readRequestBody(request);
-      logStderr('[mcp-http] body', { body: rawBody });
-      const message = JSON.parse(rawBody) as JsonRpcMessage;
+  httpServer = await startConfiguredHttpServer({
+    host: options.host,
+    port: options.port,
+    log: logStderr,
+    onMessage: async (connection, message) => {
       await server.processIncomingMessage(connection, message);
-
-      if (!replied) {
-        response.writeHead(204, {
-          'Access-Control-Allow-Origin': '*',
-          'Access-Control-Allow-Headers': 'Content-Type',
-        });
-        response.end();
-      }
-    } catch (error) {
-      logStderr('[mcp-http] error', {
-        message: error instanceof Error ? error.message : 'Unknown error',
-        url: request.url ?? '/',
-      });
-      const fallbackId = 'id' in (error as object) ? undefined : null;
-      sendHttpJson(response, 400, {
-        jsonrpc: JSON_RPC_VERSION,
-        id: fallbackId,
-        error: toJsonError(error ?? new Error(`Invalid request body`)),
-      });
-    }
-  });
-
-  await new Promise<void>((resolve, reject) => {
-    httpServer?.on('error', reject);
-    httpServer?.listen(options.port, options.host, () => resolve());
+    },
   });
 };
 

--- a/mcp-server/src/logger.ts
+++ b/mcp-server/src/logger.ts
@@ -1,0 +1,16 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import pino from 'pino';
+
+export const createMcpLogger = async (logPath: string): Promise<pino.Logger> => {
+  await fs.mkdir(path.dirname(logPath), { recursive: true });
+  const destination = pino.destination({ dest: logPath, sync: true });
+  return pino(
+    {
+      level: process.env.DEBUG_LEVEL && process.env.DEBUG_LEVEL !== '' ? process.env.DEBUG_LEVEL : 'info',
+      base: undefined,
+      depthLimit: 20,
+    },
+    destination,
+  );
+};

--- a/mcp-server/src/proof-server-manager.test.ts
+++ b/mcp-server/src/proof-server-manager.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ProofServerManager } from './proof-server-manager.js';
+
+describe('ProofServerManager', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not start docker when the proof server is already reachable', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ status: 200 })));
+    const manager = new ProofServerManager({
+      url: 'http://127.0.0.1:6300',
+      autoStart: true,
+      shutdownOnExit: false,
+      stderrLog: vi.fn(),
+      pollIntervalMs: 1,
+      startupTimeoutMs: 50,
+    });
+
+    await manager.ensureReady();
+
+    expect(true).toBe(true);
+  });
+
+  it('does not auto-start when disabled', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      throw new Error('down');
+    }));
+    const manager = new ProofServerManager({
+      url: 'http://127.0.0.1:6300',
+      autoStart: false,
+      shutdownOnExit: false,
+      stderrLog: vi.fn(),
+    });
+
+    await manager.ensureReady();
+
+    expect(true).toBe(true);
+  });
+
+  it('starts docker compose when unreachable and auto-start is enabled', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('down'))
+      .mockRejectedValueOnce(new Error('still down'))
+      .mockResolvedValue({ status: 200 });
+    vi.stubGlobal('fetch', fetchMock);
+    const runCommandMock = vi.fn(async () => undefined);
+
+    const manager = new ProofServerManager({
+      url: 'http://127.0.0.1:6300',
+      autoStart: true,
+      shutdownOnExit: false,
+      stderrLog: vi.fn(),
+      pollIntervalMs: 1,
+      startupTimeoutMs: 50,
+      runCommand: runCommandMock,
+      sleep: async () => undefined,
+    });
+
+    await manager.ensureReady();
+
+    expect(runCommandMock).toHaveBeenCalledOnce();
+  });
+
+  it('stops docker compose on shutdown only when it started it', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('down'))
+      .mockResolvedValue({ status: 200 });
+    vi.stubGlobal('fetch', fetchMock);
+    const runCommandMock = vi.fn(async () => undefined);
+
+    const manager = new ProofServerManager({
+      url: 'http://127.0.0.1:6300',
+      autoStart: true,
+      shutdownOnExit: true,
+      stderrLog: vi.fn(),
+      pollIntervalMs: 1,
+      startupTimeoutMs: 50,
+      runCommand: runCommandMock,
+      sleep: async () => undefined,
+    });
+
+    await manager.ensureReady();
+    await manager.shutdown();
+
+    expect(runCommandMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/mcp-server/src/proof-server-manager.ts
+++ b/mcp-server/src/proof-server-manager.ts
@@ -1,0 +1,97 @@
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+
+type ProofServerManagerOptions = {
+  url: string;
+  autoStart: boolean;
+  shutdownOnExit: boolean;
+  stderrLog: (message: string, extra?: Record<string, unknown>) => void;
+};
+
+const ROOT_DIR = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..', '..');
+const COMPOSE_FILE = path.join(ROOT_DIR, 'bboard-cli', 'proof-server-local.yml');
+
+const runCommand = async (
+  command: string,
+  args: string[],
+  cwd: string,
+): Promise<void> => {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      stdio: 'ignore',
+    });
+
+    child.on('error', reject);
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`${command} ${args.join(' ')} exited with code ${code ?? 'unknown'}`));
+    });
+  });
+};
+
+export class ProofServerManager {
+  private startedByManager = false;
+
+  constructor(private readonly options: ProofServerManagerOptions) {}
+
+  get url(): string {
+    return this.options.url;
+  }
+
+  async ensureReady(): Promise<void> {
+    if (await this.isReachable()) {
+      this.options.stderrLog('[proof-server] reachable', { url: this.options.url });
+      return;
+    }
+
+    if (!this.options.autoStart) {
+      this.options.stderrLog('[proof-server] unreachable', { url: this.options.url, autoStart: false });
+      return;
+    }
+
+    this.options.stderrLog('[proof-server] starting docker compose', {
+      url: this.options.url,
+      composeFile: COMPOSE_FILE,
+    });
+    await runCommand('docker', ['compose', '-f', COMPOSE_FILE, 'up', '-d'], ROOT_DIR);
+    this.startedByManager = true;
+
+    const deadline = Date.now() + 60_000;
+    while (Date.now() < deadline) {
+      if (await this.isReachable()) {
+        this.options.stderrLog('[proof-server] ready', { url: this.options.url });
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1_000));
+    }
+
+    throw new Error(`Proof server did not become reachable at ${this.options.url} within 60s`);
+  }
+
+  async shutdown(): Promise<void> {
+    if (!this.options.shutdownOnExit || !this.startedByManager) {
+      return;
+    }
+
+    this.options.stderrLog('[proof-server] stopping docker compose', {
+      composeFile: COMPOSE_FILE,
+    });
+    await runCommand('docker', ['compose', '-f', COMPOSE_FILE, 'down'], ROOT_DIR);
+  }
+
+  private async isReachable(): Promise<boolean> {
+    try {
+      const response = await fetch(this.options.url, {
+        method: 'GET',
+        redirect: 'manual',
+      });
+      return response.status < 500;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/mcp-server/src/proof-server-manager.ts
+++ b/mcp-server/src/proof-server-manager.ts
@@ -6,6 +6,10 @@ type ProofServerManagerOptions = {
   autoStart: boolean;
   shutdownOnExit: boolean;
   stderrLog: (message: string, extra?: Record<string, unknown>) => void;
+  startupTimeoutMs?: number;
+  pollIntervalMs?: number;
+  runCommand?: (command: string, args: string[], cwd: string) => Promise<void>;
+  sleep?: (ms: number) => Promise<void>;
 };
 
 const ROOT_DIR = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..', '..');
@@ -57,19 +61,23 @@ export class ProofServerManager {
       url: this.options.url,
       composeFile: COMPOSE_FILE,
     });
-    await runCommand('docker', ['compose', '-f', COMPOSE_FILE, 'up', '-d'], ROOT_DIR);
+    const runCompose = this.options.runCommand ?? runCommand;
+    const sleep = this.options.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+    await runCompose('docker', ['compose', '-f', COMPOSE_FILE, 'up', '-d'], ROOT_DIR);
     this.startedByManager = true;
 
-    const deadline = Date.now() + 60_000;
+    const startupTimeoutMs = this.options.startupTimeoutMs ?? 60_000;
+    const pollIntervalMs = this.options.pollIntervalMs ?? 1_000;
+    const deadline = Date.now() + startupTimeoutMs;
     while (Date.now() < deadline) {
       if (await this.isReachable()) {
         this.options.stderrLog('[proof-server] ready', { url: this.options.url });
         return;
       }
-      await new Promise((resolve) => setTimeout(resolve, 1_000));
+      await sleep(pollIntervalMs);
     }
 
-    throw new Error(`Proof server did not become reachable at ${this.options.url} within 60s`);
+    throw new Error(`Proof server did not become reachable at ${this.options.url} within ${startupTimeoutMs}ms`);
   }
 
   async shutdown(): Promise<void> {
@@ -80,7 +88,8 @@ export class ProofServerManager {
     this.options.stderrLog('[proof-server] stopping docker compose', {
       composeFile: COMPOSE_FILE,
     });
-    await runCommand('docker', ['compose', '-f', COMPOSE_FILE, 'down'], ROOT_DIR);
+    const runCompose = this.options.runCommand ?? runCommand;
+    await runCompose('docker', ['compose', '-f', COMPOSE_FILE, 'down'], ROOT_DIR);
   }
 
   private async isReachable(): Promise<boolean> {

--- a/mcp-server/src/protocol.ts
+++ b/mcp-server/src/protocol.ts
@@ -1,0 +1,128 @@
+export const JSON_RPC_VERSION = '2.0';
+
+export const SUPPORTED_PROTOCOL_VERSIONS = ['2025-06-18', '2025-03-26', '2024-11-05'] as const;
+export const DEFAULT_PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS[0];
+
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+export type JsonObject = { [key: string]: JsonValue };
+export type RequestId = string | number;
+
+export type JsonRpcRequest = {
+  jsonrpc: typeof JSON_RPC_VERSION;
+  id: RequestId;
+  method: string;
+  params?: JsonValue;
+};
+
+export type JsonRpcNotification = {
+  jsonrpc: typeof JSON_RPC_VERSION;
+  method: string;
+  params?: JsonValue;
+};
+
+export type JsonRpcErrorObject = {
+  code: number;
+  message: string;
+  data?: JsonValue;
+};
+
+export type JsonRpcResponse = {
+  jsonrpc: typeof JSON_RPC_VERSION;
+  id: RequestId;
+  result?: JsonValue;
+  error?: JsonRpcErrorObject;
+};
+
+export type JsonRpcMessage = JsonRpcRequest | JsonRpcNotification | JsonRpcResponse;
+
+export const ErrorCodes = {
+  parseError: -32700,
+  invalidRequest: -32600,
+  methodNotFound: -32601,
+  invalidParams: -32602,
+  internalError: -32603,
+} as const;
+
+export class JsonRpcError extends Error {
+  constructor(
+    public readonly code: number,
+    message: string,
+    public readonly data?: JsonValue,
+  ) {
+    super(message);
+  }
+}
+
+export const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export const isJsonRpcRequest = (value: unknown): value is JsonRpcRequest =>
+  isRecord(value) &&
+  value.jsonrpc === JSON_RPC_VERSION &&
+  typeof value.method === 'string' &&
+  (typeof value.id === 'string' || typeof value.id === 'number');
+
+export const isJsonRpcNotification = (value: unknown): value is JsonRpcNotification =>
+  isRecord(value) && value.jsonrpc === JSON_RPC_VERSION && typeof value.method === 'string' && value.id === undefined;
+
+export const asObject = (value: unknown, message: string): Record<string, unknown> => {
+  if (!isRecord(value)) {
+    throw new JsonRpcError(ErrorCodes.invalidParams, message);
+  }
+  return value;
+};
+
+export const asString = (value: unknown, field: string): string => {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new JsonRpcError(ErrorCodes.invalidParams, `Expected '${field}' to be a non-empty string`);
+  }
+  return value;
+};
+
+export const asOptionalString = (value: unknown, field: string): string | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+  return asString(value, field);
+};
+
+export const asOptionalBoolean = (value: unknown, field: string): boolean | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== 'boolean') {
+    throw new JsonRpcError(ErrorCodes.invalidParams, `Expected '${field}' to be a boolean`);
+  }
+  return value;
+};
+
+export const asOptionalNumber = (value: unknown, field: string): number | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    throw new JsonRpcError(ErrorCodes.invalidParams, `Expected '${field}' to be a number`);
+  }
+  return value;
+};
+
+export const maybeStringArray = (value: unknown, field: string): string[] | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    throw new JsonRpcError(ErrorCodes.invalidParams, `Expected '${field}' to be an array of strings`);
+  }
+  return value;
+};
+
+export const toJsonError = (error: unknown): JsonRpcErrorObject => {
+  if (error instanceof JsonRpcError) {
+    return { code: error.code, message: error.message, data: error.data };
+  }
+  if (error instanceof Error) {
+    return { code: ErrorCodes.internalError, message: error.message };
+  }
+  return { code: ErrorCodes.internalError, message: 'Unknown error' };
+};

--- a/mcp-server/src/server.test.ts
+++ b/mcp-server/src/server.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it, vi } from 'vitest';
+import { BBoardMcpServer, type BBoardSessionService } from './server.js';
+import { JSON_RPC_VERSION, ErrorCodes, type JsonRpcMessage } from './protocol.js';
+import { type SessionSummary } from './session-manager.js';
+import { type McpConnection, type McpTransport } from './transports.js';
+
+class NoopTransport implements McpTransport {
+  async listen(): Promise<void> {}
+}
+
+const createSessions = (): BBoardSessionService => ({
+  createSession: vi.fn(async () => ({
+    sessionId: 's1',
+    network: 'preview',
+    walletSeed: 'wallet',
+    agentSecretKey: 'agent',
+    boardJoined: false,
+    hasAdminSecret: false,
+    logPath: '/tmp/log',
+    privateStateStoreName: 'store',
+  } satisfies SessionSummary)),
+  getSessionSummary: vi.fn(async () => ({
+    sessionId: 's1',
+    network: 'preview',
+    walletSeed: 'wallet',
+    agentSecretKey: 'agent',
+    boardJoined: false,
+    hasAdminSecret: false,
+    logPath: '/tmp/log',
+    privateStateStoreName: 'store',
+  } satisfies SessionSummary)),
+  setAdminSecret: vi.fn(async () => ({
+    sessionId: 's1',
+    network: 'preview',
+    walletSeed: 'wallet',
+    agentSecretKey: 'agent',
+    boardJoined: false,
+    hasAdminSecret: true,
+    logPath: '/tmp/log',
+    privateStateStoreName: 'store',
+  } satisfies SessionSummary)),
+  waitForWalletReady: vi.fn(async () => ({
+    sessionId: 's1',
+    network: 'preview',
+    walletSeed: 'wallet',
+    agentSecretKey: 'agent',
+    boardJoined: false,
+    hasAdminSecret: false,
+    logPath: '/tmp/log',
+    privateStateStoreName: 'store',
+  } satisfies SessionSummary)),
+  deployBoard: vi.fn(async () => ({
+    session: {
+      sessionId: 's1',
+      network: 'preview',
+      walletSeed: 'wallet',
+      agentSecretKey: 'agent',
+      boardJoined: true,
+      hasAdminSecret: false,
+      logPath: '/tmp/log',
+      privateStateStoreName: 'store',
+    } satisfies SessionSummary,
+    contractAddress: 'abc',
+  })),
+  joinBoard: vi.fn(async () => ({
+    session: {
+      sessionId: 's1',
+      network: 'preview',
+      walletSeed: 'wallet',
+      agentSecretKey: 'agent',
+      boardJoined: true,
+      hasAdminSecret: false,
+      logPath: '/tmp/log',
+      privateStateStoreName: 'store',
+    } satisfies SessionSummary,
+    contractAddress: 'abc',
+  })),
+  getBoardState: vi.fn(async () => ({
+    session: {
+      sessionId: 's1',
+      network: 'preview',
+      walletSeed: 'wallet',
+      agentSecretKey: 'agent',
+      boardJoined: true,
+      hasAdminSecret: false,
+      logPath: '/tmp/log',
+      privateStateStoreName: 'store',
+    } satisfies SessionSummary,
+    contractAddress: 'abc',
+    derivedState: { state: 'VACANT' },
+    ledgerState: { pendingState: 'VACANT' },
+  })),
+  submitPost: vi.fn(async () => ({ ok: true })),
+  withdrawPending: vi.fn(async () => ({ ok: true })),
+  approvePending: vi.fn(async () => ({ ok: true })),
+  rejectPending: vi.fn(async () => ({ ok: true })),
+  unpublishPublished: vi.fn(async () => ({ ok: true })),
+  closeSession: vi.fn(async () => ({ sessionId: 's1', closed: true as const })),
+  closeAll: vi.fn(async () => undefined),
+});
+
+const createConnection = () => {
+  const messages: JsonRpcMessage[] = [];
+  const connection: McpConnection = {
+    id: 'test-connection',
+    send: (message) => {
+      messages.push(message);
+    },
+  };
+  return { connection, messages };
+};
+
+describe('BBoardMcpServer', () => {
+  it('requires initialize before requests by default', async () => {
+    const sessions = createSessions();
+    const server = new BBoardMcpServer(new NoopTransport(), {}, sessions);
+    const { connection, messages } = createConnection();
+
+    await server.processIncomingMessage(connection, {
+      jsonrpc: JSON_RPC_VERSION,
+      id: 1,
+      method: 'tools/list',
+    });
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      jsonrpc: JSON_RPC_VERSION,
+      id: 1,
+      error: { code: ErrorCodes.invalidRequest },
+    });
+  });
+
+  it('returns tools after initialization notification', async () => {
+    const sessions = createSessions();
+    const server = new BBoardMcpServer(new NoopTransport(), {}, sessions);
+    const { connection, messages } = createConnection();
+
+    await server.processIncomingMessage(connection, {
+      jsonrpc: JSON_RPC_VERSION,
+      method: 'notifications/initialized',
+    });
+
+    await server.processIncomingMessage(connection, {
+      jsonrpc: JSON_RPC_VERSION,
+      id: 2,
+      method: 'tools/list',
+    });
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      jsonrpc: JSON_RPC_VERSION,
+      id: 2,
+      result: {
+        tools: expect.arrayContaining([
+          expect.objectContaining({ name: 'bboard_create_session' }),
+          expect.objectContaining({ name: 'bboard_set_admin_secret' }),
+        ]),
+      },
+    });
+  });
+
+  it('can skip initialize when configured', async () => {
+    const sessions = createSessions();
+    const server = new BBoardMcpServer(new NoopTransport(), { requireInitialize: false }, sessions);
+    const { connection, messages } = createConnection();
+
+    await server.processIncomingMessage(connection, {
+      jsonrpc: JSON_RPC_VERSION,
+      id: 3,
+      method: 'resources/list',
+    });
+
+    expect(messages[0]).toMatchObject({
+      id: 3,
+      result: {
+        resources: expect.arrayContaining([
+          expect.objectContaining({ uri: 'docs://agent-workflow' }),
+          expect.objectContaining({ uri: 'docs://credential-model' }),
+        ]),
+      },
+    });
+  });
+
+  it('delegates tool calls to the session service', async () => {
+    const sessions = createSessions();
+    const server = new BBoardMcpServer(new NoopTransport(), { requireInitialize: false }, sessions);
+    const { connection, messages } = createConnection();
+
+    await server.processIncomingMessage(connection, {
+      jsonrpc: JSON_RPC_VERSION,
+      id: 4,
+      method: 'tools/call',
+      params: {
+        name: 'bboard_create_session',
+        arguments: {
+          network: 'preview',
+        },
+      },
+    });
+
+    expect(sessions.createSession).toHaveBeenCalledWith({ network: 'preview', sessionId: undefined, walletSeed: undefined, agentSecretKey: undefined, adminSecret: undefined });
+    expect(messages[0]).toMatchObject({
+      id: 4,
+      result: {
+        structuredContent: expect.objectContaining({
+          sessionId: 's1',
+          hasAdminSecret: false,
+        }),
+      },
+    });
+  });
+
+  it('returns the operator prompt', async () => {
+    const sessions = createSessions();
+    const server = new BBoardMcpServer(new NoopTransport(), { requireInitialize: false }, sessions);
+    const { connection, messages } = createConnection();
+
+    await server.processIncomingMessage(connection, {
+      jsonrpc: JSON_RPC_VERSION,
+      id: 5,
+      method: 'prompts/get',
+      params: {
+        name: 'bboard_operator',
+      },
+    });
+
+    expect(messages[0]).toMatchObject({
+      id: 5,
+      result: {
+        description: 'Operational prompt for a bulletin-board agent',
+      },
+    });
+  });
+});

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -1,0 +1,495 @@
+import * as fs from 'node:fs/promises';
+import path from 'node:path';
+import {
+  JSON_RPC_VERSION,
+  DEFAULT_PROTOCOL_VERSION,
+  ErrorCodes,
+  JsonRpcError,
+  JsonRpcMessage,
+  JsonRpcRequest,
+  JsonValue,
+  SUPPORTED_PROTOCOL_VERSIONS,
+  asObject,
+  asOptionalBoolean,
+  asOptionalNumber,
+  asOptionalString,
+  asString,
+  isJsonRpcNotification,
+  isJsonRpcRequest,
+  toJsonError,
+} from './protocol.js';
+import { type McpConnection, type McpTransport } from './transports.js';
+import { BBoardSessionManager } from './session-manager.js';
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<JsonValue>;
+
+type ToolDefinition = {
+  name: string;
+  description: string;
+  inputSchema: JsonValue;
+  handler: ToolHandler;
+};
+
+const resolveDocsDir = async (): Promise<string> => {
+  const candidates = [
+    path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', 'docs'),
+    path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..', '..', 'docs'),
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      await fs.access(candidate);
+      return candidate;
+    } catch {
+      continue;
+    }
+  }
+
+  throw new Error('Could not locate MCP documentation directory');
+};
+
+const toToolResult = (structuredContent: JsonValue, text: string, isError = false): JsonValue => ({
+  content: [{ type: 'text', text }],
+  structuredContent,
+  isError,
+});
+
+const stringify = (value: JsonValue): string => JSON.stringify(value, null, 2);
+
+type BBoardMcpServerOptions = {
+  requireInitialize?: boolean;
+};
+
+export class BBoardMcpServer {
+  private readonly sessions = new BBoardSessionManager();
+  private readonly initializedConnections = new Set<string>();
+  private readonly requireInitialize: boolean;
+
+  private readonly tools: ToolDefinition[] = [
+    {
+      name: 'bboard_create_session',
+      description:
+        'Create a reusable agent session. A session owns one wallet seed and one bulletin-board agent secret. Admin secret is optional write-only input.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          network: { type: 'string', enum: ['preview', 'preprod', 'standalone'], default: 'preview' },
+          sessionId: { type: 'string' },
+          walletSeed: { type: 'string', description: 'Optional 32-byte wallet seed in hex. Generated when omitted.' },
+          agentSecretKey: {
+            type: 'string',
+            description: 'Optional 32-byte contract secret in hex for the posting agent. Generated when omitted.',
+          },
+          adminSecret: {
+            type: 'string',
+            description: 'Optional write-only 32-byte admin secret in hex. It is accepted but never returned by the server.',
+          },
+        },
+        additionalProperties: false,
+      },
+      handler: async (args) =>
+        await this.sessions.createSession({
+          network: asOptionalString(args.network, 'network') as 'preview' | 'preprod' | 'standalone' | undefined,
+          sessionId: asOptionalString(args.sessionId, 'sessionId'),
+          walletSeed: asOptionalString(args.walletSeed, 'walletSeed'),
+          agentSecretKey: asOptionalString(args.agentSecretKey, 'agentSecretKey'),
+          adminSecret: asOptionalString(args.adminSecret, 'adminSecret'),
+        }),
+    },
+    {
+      name: 'bboard_get_session',
+      description: 'Return the current non-admin credentials, wallet address, balance, and board binding for a session.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionId: { type: 'string' },
+        },
+        required: ['sessionId'],
+        additionalProperties: false,
+      },
+      handler: async (args) => await this.sessions.getSessionSummary(asString(args.sessionId, 'sessionId')),
+    },
+    {
+      name: 'bboard_set_admin_secret',
+      description: 'Write-only admin secret setter for a session. The server never returns the admin secret.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionId: { type: 'string' },
+          adminSecret: { type: 'string' },
+        },
+        required: ['sessionId', 'adminSecret'],
+        additionalProperties: false,
+      },
+      handler: async (args) =>
+        await this.sessions.setAdminSecret(
+          asString(args.sessionId, 'sessionId'),
+          asString(args.adminSecret, 'adminSecret'),
+        ),
+    },
+    {
+      name: 'bboard_wait_for_wallet_ready',
+      description:
+        'Sync the wallet for a session and, when applicable, register dust for Midnight transactions. Use this before sending transactions.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionId: { type: 'string' },
+          timeoutMs: { type: 'number', minimum: 1_000 },
+        },
+        required: ['sessionId'],
+        additionalProperties: false,
+      },
+      handler: async (args) =>
+        await this.sessions.waitForWalletReady(
+          asString(args.sessionId, 'sessionId'),
+          asOptionalNumber(args.timeoutMs, 'timeoutMs'),
+        ),
+    },
+    {
+      name: 'bboard_deploy_board',
+      description: 'Deploy a new bulletin-board contract using the identity stored in the session.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionId: { type: 'string' },
+        },
+        required: ['sessionId'],
+        additionalProperties: false,
+      },
+      handler: async (args) => await this.sessions.deployBoard(asString(args.sessionId, 'sessionId')),
+    },
+    {
+      name: 'bboard_join_board',
+      description: 'Join an existing bulletin-board contract by contract address.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionId: { type: 'string' },
+          contractAddress: { type: 'string' },
+        },
+        required: ['sessionId', 'contractAddress'],
+        additionalProperties: false,
+      },
+      handler: async (args) =>
+        await this.sessions.joinBoard(
+          asString(args.sessionId, 'sessionId'),
+          asString(args.contractAddress, 'contractAddress'),
+        ),
+    },
+    {
+      name: 'bboard_get_board_state',
+      description: 'Read both derived state and raw ledger state for the board currently attached to the session.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionId: { type: 'string' },
+        },
+        required: ['sessionId'],
+        additionalProperties: false,
+      },
+      handler: async (args) => await this.sessions.getBoardState(asString(args.sessionId, 'sessionId')),
+    },
+    {
+      name: 'bboard_submit_post',
+      description: 'Submit a post into the pending board as the current agent identity.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionId: { type: 'string' },
+          message: { type: 'string' },
+        },
+        required: ['sessionId', 'message'],
+        additionalProperties: false,
+      },
+      handler: async (args) =>
+        await this.sessions.submitPost(asString(args.sessionId, 'sessionId'), asString(args.message, 'message')),
+    },
+    {
+      name: 'bboard_withdraw_pending',
+      description: 'Withdraw the current pending post if the session owns it.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionId: { type: 'string' },
+        },
+        required: ['sessionId'],
+        additionalProperties: false,
+      },
+      handler: async (args) => await this.sessions.withdrawPending(asString(args.sessionId, 'sessionId')),
+    },
+    {
+      name: 'bboard_approve_pending',
+      description: 'Approve the pending post as admin. This requires the correct admin secret in the session.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionId: { type: 'string' },
+        },
+        required: ['sessionId'],
+        additionalProperties: false,
+      },
+      handler: async (args) => await this.sessions.approvePending(asString(args.sessionId, 'sessionId')),
+    },
+    {
+      name: 'bboard_reject_pending',
+      description: 'Reject the pending post as admin. This requires the correct admin secret in the session.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionId: { type: 'string' },
+        },
+        required: ['sessionId'],
+        additionalProperties: false,
+      },
+      handler: async (args) => await this.sessions.rejectPending(asString(args.sessionId, 'sessionId')),
+    },
+    {
+      name: 'bboard_unpublish_published',
+      description: 'Unpublish the current published post as admin. This requires the correct admin secret in the session.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionId: { type: 'string' },
+        },
+        required: ['sessionId'],
+        additionalProperties: false,
+      },
+      handler: async (args) => await this.sessions.unpublishPublished(asString(args.sessionId, 'sessionId')),
+    },
+    {
+      name: 'bboard_close_session',
+      description: 'Stop the wallet, shut down the local proof-server environment, and release session resources.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          sessionId: { type: 'string' },
+        },
+        required: ['sessionId'],
+        additionalProperties: false,
+      },
+      handler: async (args) => await this.sessions.closeSession(asString(args.sessionId, 'sessionId')),
+    },
+  ];
+
+  constructor(
+    private readonly transport: McpTransport,
+    options: BBoardMcpServerOptions = {},
+  ) {
+    this.requireInitialize = options.requireInitialize ?? true;
+  }
+
+  async start(): Promise<void> {
+    await this.transport.listen(async (connection, message) => {
+      await this.processIncomingMessage(connection, message);
+    });
+  }
+
+  async shutdown(): Promise<void> {
+    await this.sessions.closeAll();
+    if (this.transport.close) {
+      await this.transport.close();
+    }
+  }
+
+  async processIncomingMessage(connection: McpConnection, message: JsonRpcMessage): Promise<void> {
+    if (isJsonRpcRequest(message)) {
+      await this.handleRequest(connection, message);
+      return;
+    }
+
+    if (isJsonRpcNotification(message)) {
+      await this.handleNotification(connection, message.method);
+    }
+  }
+
+  private async handleRequest(connection: McpConnection, request: JsonRpcRequest): Promise<void> {
+    try {
+      if (
+        this.requireInitialize &&
+        !this.initializedConnections.has(connection.id) &&
+        request.method !== 'initialize' &&
+        request.method !== 'ping'
+      ) {
+        throw new JsonRpcError(ErrorCodes.invalidRequest, 'Server has not been initialized yet');
+      }
+
+      let result: JsonValue;
+      switch (request.method) {
+        case 'initialize':
+          result = this.handleInitialize(request.params);
+          break;
+        case 'ping':
+          result = {};
+          break;
+        case 'tools/list':
+          result = { tools: this.tools.map(({ handler: _handler, ...tool }) => tool) };
+          break;
+        case 'tools/call':
+          result = await this.handleToolCall(request.params);
+          break;
+        case 'resources/list':
+          result = {
+            resources: [
+              {
+                uri: 'docs://agent-workflow',
+                name: 'Agent Workflow',
+                description: 'Step-by-step instructions for using this bulletin board MCP server from an agent.',
+                mimeType: 'text/markdown',
+              },
+              {
+                uri: 'docs://credential-model',
+                name: 'Credential Model',
+                description: 'Explains the wallet seed, agent secret, and write-only admin secret handling used by this server.',
+                mimeType: 'text/markdown',
+              },
+            ],
+          };
+          break;
+        case 'resources/read':
+          result = await this.handleReadResource(request.params);
+          break;
+        case 'prompts/list':
+          result = {
+            prompts: [
+              {
+                name: 'bboard_operator',
+                description: 'Operating guide for an agent that needs to use the bulletin board safely.',
+              },
+            ],
+          };
+          break;
+        case 'prompts/get':
+          result = await this.handlePromptGet(request.params);
+          break;
+        default:
+          throw new JsonRpcError(ErrorCodes.methodNotFound, `Unknown method '${request.method}'`);
+      }
+
+      connection.send({
+        jsonrpc: JSON_RPC_VERSION,
+        id: request.id,
+        result,
+      });
+    } catch (error) {
+      connection.send({
+        jsonrpc: JSON_RPC_VERSION,
+        id: request.id,
+        error: toJsonError(error),
+      });
+    }
+  }
+
+  private async handleNotification(connection: McpConnection, method: string): Promise<void> {
+    if (method === 'notifications/initialized') {
+      this.initializedConnections.add(connection.id);
+    }
+  }
+
+  private handleInitialize(params: unknown): JsonValue {
+    const payload = asObject(params, 'Expected initialize params');
+    const requestedVersion = asString(payload.protocolVersion, 'protocolVersion');
+    const protocolVersion = SUPPORTED_PROTOCOL_VERSIONS.includes(requestedVersion as (typeof SUPPORTED_PROTOCOL_VERSIONS)[number])
+      ? requestedVersion
+      : DEFAULT_PROTOCOL_VERSION;
+
+    return {
+      protocolVersion,
+      capabilities: {
+        tools: {},
+        resources: {},
+        prompts: {},
+      },
+      serverInfo: {
+        name: 'example-bboard-mcp-server',
+        version: '0.1.0',
+      },
+      instructions:
+        'Create a session first. Persist walletSeed, agentSecretKey, and contractAddress outside the server so the same identity can be reused later. Admin secret is write-only input and is never returned. Call bboard_wait_for_wallet_ready before sending transactions.',
+    };
+  }
+
+  private async handleToolCall(params: unknown): Promise<JsonValue> {
+    const payload = asObject(params, 'Expected tools/call params');
+    const name = asString(payload.name, 'name');
+    const args = asObject(payload.arguments ?? {}, "Expected 'arguments' to be an object");
+    const tool = this.tools.find((candidate) => candidate.name === name);
+
+    if (!tool) {
+      throw new JsonRpcError(ErrorCodes.invalidParams, `Unknown tool '${name}'`);
+    }
+
+    try {
+      const structuredContent = await tool.handler(args);
+      return toToolResult(structuredContent, stringify(structuredContent));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown tool error';
+      return toToolResult({ tool: name, error: message }, message, true);
+    }
+  }
+
+  private async handleReadResource(params: unknown): Promise<JsonValue> {
+    const payload = asObject(params, 'Expected resources/read params');
+    const uri = asString(payload.uri, 'uri');
+
+    let fileName: string;
+    switch (uri) {
+      case 'docs://agent-workflow':
+        fileName = 'AGENT_WORKFLOW.md';
+        break;
+      case 'docs://credential-model':
+        fileName = 'CREDENTIAL_MODEL.md';
+        break;
+      default:
+        throw new JsonRpcError(ErrorCodes.invalidParams, `Unknown resource '${uri}'`);
+    }
+
+    const docsDir = await resolveDocsDir();
+    const text = await fs.readFile(path.join(docsDir, fileName), 'utf8');
+    return {
+      contents: [
+        {
+          uri,
+          mimeType: 'text/markdown',
+          text,
+        },
+      ],
+    };
+  }
+
+  private async handlePromptGet(params: unknown): Promise<JsonValue> {
+    const payload = asObject(params, 'Expected prompts/get params');
+    const name = asString(payload.name, 'name');
+    const promptArgs = payload.arguments ? asObject(payload.arguments, "Expected 'arguments' to be an object") : {};
+
+    if (name !== 'bboard_operator') {
+      throw new JsonRpcError(ErrorCodes.invalidParams, `Unknown prompt '${name}'`);
+    }
+
+    const emphasizeModeration = asOptionalBoolean(promptArgs.emphasizeModeration, 'emphasizeModeration') ?? true;
+
+    const promptText = [
+      'Operate the bulletin board through MCP tools only.',
+      'Start by calling bboard_create_session, then bboard_wait_for_wallet_ready.',
+      'Persist walletSeed, agentSecretKey, and contractAddress after creation or deployment.',
+      'Admin secret is write-only input. Provide it through bboard_create_session or bboard_set_admin_secret, but do not expect the server to ever return it.',
+      'Use bboard_get_board_state before acting when you need current context.',
+      emphasizeModeration
+        ? 'Never call admin moderation tools unless you are explicitly using the correct write-only admin secret for that board.'
+        : 'Admin moderation tools require the board admin secret as write-only input.',
+    ].join(' ');
+
+    return {
+      description: 'Operational prompt for a bulletin-board agent',
+      messages: [
+        {
+          role: 'user',
+          content: {
+            type: 'text',
+            text: promptText,
+          },
+        },
+      ],
+    };
+  }
+}

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -23,6 +23,23 @@ import { BBoardSessionManager } from './session-manager.js';
 
 type ToolHandler = (args: Record<string, unknown>) => Promise<JsonValue>;
 
+export type BBoardSessionService = {
+  createSession: BBoardSessionManager['createSession'];
+  getSessionSummary: BBoardSessionManager['getSessionSummary'];
+  setAdminSecret: BBoardSessionManager['setAdminSecret'];
+  waitForWalletReady: BBoardSessionManager['waitForWalletReady'];
+  deployBoard: BBoardSessionManager['deployBoard'];
+  joinBoard: BBoardSessionManager['joinBoard'];
+  getBoardState: BBoardSessionManager['getBoardState'];
+  submitPost: BBoardSessionManager['submitPost'];
+  withdrawPending: BBoardSessionManager['withdrawPending'];
+  approvePending: BBoardSessionManager['approvePending'];
+  rejectPending: BBoardSessionManager['rejectPending'];
+  unpublishPublished: BBoardSessionManager['unpublishPublished'];
+  closeSession: BBoardSessionManager['closeSession'];
+  closeAll: BBoardSessionManager['closeAll'];
+};
+
 type ToolDefinition = {
   name: string;
   description: string;
@@ -61,7 +78,6 @@ type BBoardMcpServerOptions = {
 };
 
 export class BBoardMcpServer {
-  private readonly sessions = new BBoardSessionManager();
   private readonly initializedConnections = new Set<string>();
   private readonly requireInitialize: boolean;
 
@@ -275,6 +291,7 @@ export class BBoardMcpServer {
   constructor(
     private readonly transport: McpTransport,
     options: BBoardMcpServerOptions = {},
+    private readonly sessions: BBoardSessionService = new BBoardSessionManager(),
   ) {
     this.requireInitialize = options.requireInitialize ?? true;
   }

--- a/mcp-server/src/session-manager.ts
+++ b/mcp-server/src/session-manager.ts
@@ -1,0 +1,355 @@
+import path from 'node:path';
+import { randomBytes } from 'node:crypto';
+import { firstValueFrom } from 'rxjs';
+import { NodeZkConfigProvider } from '@midnight-ntwrk/midnight-js-node-zk-config-provider';
+import { indexerPublicDataProvider } from '@midnight-ntwrk/midnight-js-indexer-public-data-provider';
+import { httpClientProofProvider } from '@midnight-ntwrk/midnight-js-http-client-proof-provider';
+import { levelPrivateStateProvider } from '@midnight-ntwrk/midnight-js-level-private-state-provider';
+import { type Logger } from 'pino';
+import { UnshieldedAddress } from '@midnight-ntwrk/wallet-sdk-address-format';
+import { unshieldedToken } from '@midnight-ntwrk/ledger-v7';
+import { getNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+import { toHex } from '@midnight-ntwrk/midnight-js-utils';
+import { BBoardAPI, type BBoardCircuitKeys, type BBoardDerivedState, bboardPrivateStateKey, type BBoardProviders } from '../../api/src/index.js';
+import { createBBoardPrivateState, PostState, ledger } from '../../contract/src/index.js';
+import { currentDir, type Config, PreviewRemoteConfig, PreprodRemoteConfig, StandaloneConfig } from '../../bboard-cli/src/config.js';
+import { MidnightWalletProvider } from '../../bboard-cli/src/midnight-wallet-provider.js';
+import { generateDust } from '../../bboard-cli/src/generate-dust.js';
+import { getInitialUnshieldedState, syncWallet } from '../../bboard-cli/src/wallet-utils.js';
+import { createMcpLogger } from './logger.js';
+import { type JsonValue } from './protocol.js';
+
+type SessionNetwork = 'preview' | 'preprod' | 'standalone';
+
+export type SessionCredentials = {
+  walletSeed: string;
+  agentSecretKey: string;
+};
+
+export type SessionSummary = SessionCredentials & {
+  sessionId: string;
+  network: SessionNetwork;
+  contractAddress?: string;
+  walletAddress?: string;
+  nightBalance?: string;
+  boardJoined: boolean;
+  hasAdminSecret: boolean;
+  logPath: string;
+  privateStateStoreName: string;
+};
+
+type SessionContext = {
+  sessionId: string;
+  network: SessionNetwork;
+  config: Config;
+  logger: Logger;
+  logPath: string;
+  testEnvironment: ReturnType<Config['getEnvironment']>;
+  walletProvider: MidnightWalletProvider;
+  providers: BBoardProviders;
+  credentials: SessionCredentials & { adminSecret?: string };
+  api?: BBoardAPI;
+};
+
+const MOUNTED_STATE_DIR = path.resolve(currentDir, '..', '..', 'mcp-state');
+
+const normalizeHexSecret = (value: string, field: string): Uint8Array => {
+  const normalized = value.toLowerCase().replace(/^0x/, '');
+  if (!/^[0-9a-f]{64}$/.test(normalized)) {
+    throw new Error(`'${field}' must be a 32-byte hex string`);
+  }
+  return Buffer.from(normalized, 'hex');
+};
+
+const randomHex32 = (): string => randomBytes(32).toString('hex');
+const randomSessionId = (): string => randomBytes(8).toString('hex');
+
+const stringifyBigInts = (value: unknown): JsonValue => {
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => stringifyBigInts(item));
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, entry]) => [key, stringifyBigInts(entry)]),
+    ) as JsonValue;
+  }
+  return (value ?? null) as JsonValue;
+};
+
+const selectConfig = (network: SessionNetwork): Config => {
+  switch (network) {
+    case 'preview':
+      return new PreviewRemoteConfig();
+    case 'preprod':
+      return new PreprodRemoteConfig();
+    case 'standalone':
+      return new StandaloneConfig();
+  }
+};
+
+export class BBoardSessionManager {
+  private readonly sessions = new Map<string, SessionContext>();
+
+  async createSession(args: {
+    network?: SessionNetwork;
+    sessionId?: string;
+    walletSeed?: string;
+    agentSecretKey?: string;
+    adminSecret?: string;
+  }): Promise<SessionSummary> {
+    const network = args.network ?? 'preview';
+    const sessionId = args.sessionId ?? randomSessionId();
+
+    if (this.sessions.has(sessionId)) {
+      throw new Error(`Session '${sessionId}' already exists`);
+    }
+
+    const config = selectConfig(network);
+    const logPath = path.resolve(MOUNTED_STATE_DIR, 'logs', `${sessionId}.log`);
+    const logger = await createMcpLogger(logPath);
+    const testEnvironment = config.getEnvironment(logger);
+    const envConfiguration = await testEnvironment.start();
+
+    const walletSeed = args.walletSeed ?? randomHex32();
+    const walletProvider = await MidnightWalletProvider.build(logger, envConfiguration, walletSeed);
+    await walletProvider.start();
+
+    const privateStateStoreName = `bboard-mcp-${sessionId}-private-state`;
+    const signingKeyStoreName = `bboard-mcp-${sessionId}-signing-keys`;
+    const midnightDbName = path.resolve(MOUNTED_STATE_DIR, sessionId, 'midnight-level-db');
+
+    const providers: BBoardProviders = {
+      privateStateProvider: levelPrivateStateProvider({
+        midnightDbName,
+        privateStateStoreName,
+        signingKeyStoreName,
+        privateStoragePasswordProvider: () => 'bboard-mcp-private-state-password',
+      }),
+      publicDataProvider: indexerPublicDataProvider(envConfiguration.indexer, envConfiguration.indexerWS),
+      zkConfigProvider: new NodeZkConfigProvider<BBoardCircuitKeys>(config.zkConfigPath),
+      proofProvider: httpClientProofProvider(envConfiguration.proofServer, new NodeZkConfigProvider<BBoardCircuitKeys>(config.zkConfigPath)),
+      walletProvider,
+      midnightProvider: walletProvider,
+    };
+
+    const credentials: SessionCredentials & { adminSecret?: string } = {
+      walletSeed,
+      agentSecretKey: args.agentSecretKey ?? randomHex32(),
+    };
+
+    if (args.adminSecret !== undefined) {
+      credentials.adminSecret = args.adminSecret;
+    }
+
+    await providers.privateStateProvider.set(
+      bboardPrivateStateKey,
+      createBBoardPrivateState(
+        normalizeHexSecret(credentials.agentSecretKey, 'agentSecretKey'),
+        normalizeHexSecret(credentials.adminSecret ?? '0'.repeat(64), 'adminSecret'),
+      ),
+    );
+
+    const session: SessionContext = {
+      sessionId,
+      network,
+      config: {
+        ...config,
+        privateStateStoreName,
+      },
+      logger,
+      logPath,
+      testEnvironment,
+      walletProvider,
+      providers,
+      credentials,
+    };
+
+    this.sessions.set(sessionId, session);
+    return this.getSessionSummary(sessionId);
+  }
+
+  async getSessionSummary(sessionId: string): Promise<SessionSummary> {
+    const session = this.requireSession(sessionId);
+    const initialState = await getInitialUnshieldedState(session.logger, session.walletProvider.wallet.unshielded);
+    const walletAddress = UnshieldedAddress.codec.encode(getNetworkId(), initialState.address).toString();
+    const nightBalance = initialState.balances[unshieldedToken().raw];
+
+    return {
+      sessionId: session.sessionId,
+      network: session.network,
+      walletSeed: session.credentials.walletSeed,
+      agentSecretKey: session.credentials.agentSecretKey,
+      contractAddress: session.api?.deployedContractAddress,
+      walletAddress,
+      nightBalance: nightBalance?.toString(),
+      boardJoined: session.api !== undefined,
+      hasAdminSecret: session.credentials.adminSecret !== undefined,
+      logPath: session.logPath,
+      privateStateStoreName: session.config.privateStateStoreName,
+    };
+  }
+
+  async setAdminSecret(sessionId: string, adminSecret: string): Promise<SessionSummary> {
+    const session = this.requireSession(sessionId);
+    session.credentials.adminSecret = adminSecret;
+    const privateState = await session.providers.privateStateProvider.get(bboardPrivateStateKey);
+    const currentSecretKey = privateState?.secretKey ?? normalizeHexSecret(session.credentials.agentSecretKey, 'agentSecretKey');
+
+    await session.providers.privateStateProvider.set(
+      bboardPrivateStateKey,
+      createBBoardPrivateState(currentSecretKey, normalizeHexSecret(adminSecret, 'adminSecret')),
+    );
+
+    return this.getSessionSummary(sessionId);
+  }
+
+  async waitForWalletReady(sessionId: string, timeoutMs = 180_000): Promise<SessionSummary> {
+    const session = this.requireSession(sessionId);
+    await syncWallet(session.logger, session.walletProvider.wallet, 2_000, timeoutMs);
+    const unshieldedState = await getInitialUnshieldedState(session.logger, session.walletProvider.wallet.unshielded);
+
+    if (session.config.generateDust) {
+      const txHash = await generateDust(
+        session.logger,
+        session.credentials.walletSeed,
+        unshieldedState,
+        session.walletProvider.wallet,
+      );
+      if (txHash) {
+        session.logger.info(`Submitted dust registration transaction: ${txHash}`);
+        await syncWallet(session.logger, session.walletProvider.wallet, 2_000, timeoutMs);
+      }
+    }
+
+    return this.getSessionSummary(sessionId);
+  }
+
+  async deployBoard(sessionId: string): Promise<{ session: SessionSummary; contractAddress: string }> {
+    const session = this.requireSession(sessionId);
+    session.api = await BBoardAPI.deploy(session.providers, session.logger);
+    return {
+      session: await this.getSessionSummary(sessionId),
+      contractAddress: session.api.deployedContractAddress,
+    };
+  }
+
+  async joinBoard(sessionId: string, contractAddress: string): Promise<{ session: SessionSummary; contractAddress: string }> {
+    const session = this.requireSession(sessionId);
+    session.api = await BBoardAPI.join(session.providers, contractAddress, session.logger);
+    return {
+      session: await this.getSessionSummary(sessionId),
+      contractAddress: session.api.deployedContractAddress,
+    };
+  }
+
+  async getBoardState(sessionId: string): Promise<{
+    session: SessionSummary;
+    derivedState: JsonValue;
+    ledgerState: JsonValue;
+    contractAddress: string;
+  }> {
+    const session = this.requireActiveBoard(sessionId);
+    const derivedState = await firstValueFrom(session.api.state$);
+    const ledgerState = await this.readLedgerState(session);
+    return {
+      session: await this.getSessionSummary(sessionId),
+      derivedState: stringifyBigInts(this.serializeDerivedState(derivedState)),
+      ledgerState: stringifyBigInts(ledgerState),
+      contractAddress: session.api.deployedContractAddress,
+    };
+  }
+
+  async submitPost(sessionId: string, message: string): Promise<JsonValue> {
+    const session = this.requireActiveBoard(sessionId);
+    await session.api.post(message);
+    return this.getBoardState(sessionId);
+  }
+
+  async withdrawPending(sessionId: string): Promise<JsonValue> {
+    const session = this.requireActiveBoard(sessionId);
+    await session.api.takeDown();
+    return this.getBoardState(sessionId);
+  }
+
+  async approvePending(sessionId: string): Promise<JsonValue> {
+    const session = this.requireActiveBoard(sessionId);
+    await session.api.approvePending();
+    return this.getBoardState(sessionId);
+  }
+
+  async rejectPending(sessionId: string): Promise<JsonValue> {
+    const session = this.requireActiveBoard(sessionId);
+    await session.api.rejectPending();
+    return this.getBoardState(sessionId);
+  }
+
+  async unpublishPublished(sessionId: string): Promise<JsonValue> {
+    const session = this.requireActiveBoard(sessionId);
+    await session.api.unpublishPublished();
+    return this.getBoardState(sessionId);
+  }
+
+  async closeSession(sessionId: string): Promise<{ sessionId: string; closed: true }> {
+    const session = this.requireSession(sessionId);
+    this.sessions.delete(sessionId);
+    await session.walletProvider.stop();
+    await session.testEnvironment.shutdown();
+    return { sessionId, closed: true };
+  }
+
+  async closeAll(): Promise<void> {
+    await Promise.all(Array.from(this.sessions.keys()).map((sessionId) => this.closeSession(sessionId)));
+  }
+
+  private requireSession(sessionId: string): SessionContext {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`Unknown session '${sessionId}'`);
+    }
+    return session;
+  }
+
+  private requireActiveBoard(sessionId: string): SessionContext & { api: BBoardAPI } {
+    const session = this.requireSession(sessionId);
+    if (!session.api) {
+      throw new Error(`Session '${sessionId}' has not joined or deployed a board yet`);
+    }
+    return session as SessionContext & { api: BBoardAPI };
+  }
+
+  private async readLedgerState(session: SessionContext & { api: BBoardAPI }): Promise<Record<string, JsonValue>> {
+    const contractState = await session.providers.publicDataProvider.queryContractState(session.api.deployedContractAddress);
+    if (contractState == null) {
+      throw new Error(`No contract state found for ${session.api.deployedContractAddress}`);
+    }
+    const currentLedger = ledger(contractState.data);
+    return {
+      pendingState: PostState[currentLedger.pendingState],
+      pendingMessage: currentLedger.pendingMessage.is_some ? currentLedger.pendingMessage.value : null,
+      pendingOwner: toHex(currentLedger.pendingOwner),
+      publishedState: PostState[currentLedger.publishedState],
+      publishedMessage: currentLedger.publishedMessage.is_some ? currentLedger.publishedMessage.value : null,
+      publishedOwner: toHex(currentLedger.publishedOwner),
+      sequence: currentLedger.sequence.toString(),
+    };
+  }
+
+  private serializeDerivedState(state: BBoardDerivedState): Record<string, JsonValue> {
+    return {
+      state: PostState[state.state],
+      sequence: state.sequence.toString(),
+      message: state.message ?? null,
+      pendingState: PostState[state.pendingState],
+      pendingMessage: state.pendingMessage ?? null,
+      pendingIsOwner: state.pendingIsOwner,
+      publishedState: PostState[state.publishedState],
+      publishedMessage: state.publishedMessage ?? null,
+      publishedIsOwner: state.publishedIsOwner,
+      isAdmin: state.isAdmin,
+      isOwner: state.isOwner,
+    };
+  }
+}

--- a/mcp-server/src/transports.ts
+++ b/mcp-server/src/transports.ts
@@ -1,0 +1,77 @@
+import { Buffer } from 'node:buffer';
+import { stdin, stdout } from 'node:process';
+import { JsonRpcMessage } from './protocol.js';
+
+const HEADER_DELIMITER = '\r\n\r\n';
+
+export type McpConnection = {
+  id: string;
+  send: (message: JsonRpcMessage) => void;
+};
+
+export type McpTransport = {
+  listen: (onMessage: (connection: McpConnection, message: JsonRpcMessage) => Promise<void>) => Promise<void>;
+  close?: () => Promise<void>;
+};
+
+class FramedMessageReader {
+  private buffer = Buffer.alloc(0);
+
+  async push(chunk: Buffer, onMessage: (message: JsonRpcMessage) => Promise<void>): Promise<void> {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+
+    while (true) {
+      const headerEnd = this.buffer.indexOf(HEADER_DELIMITER);
+      if (headerEnd === -1) {
+        return;
+      }
+
+      const headerText = this.buffer.subarray(0, headerEnd).toString('utf8');
+      const contentLengthLine = headerText
+        .split('\r\n')
+        .find((line) => line.toLowerCase().startsWith('content-length:'));
+
+      if (!contentLengthLine) {
+        throw new Error('Missing Content-Length header');
+      }
+
+      const contentLength = Number.parseInt(contentLengthLine.split(':')[1]?.trim() ?? '', 10);
+      if (Number.isNaN(contentLength)) {
+        throw new Error('Invalid Content-Length header');
+      }
+
+      const bodyStart = headerEnd + HEADER_DELIMITER.length;
+      const bodyEnd = bodyStart + contentLength;
+
+      if (this.buffer.length < bodyEnd) {
+        return;
+      }
+
+      const body = this.buffer.subarray(bodyStart, bodyEnd).toString('utf8');
+      this.buffer = this.buffer.subarray(bodyEnd);
+      await onMessage(JSON.parse(body) as JsonRpcMessage);
+    }
+  }
+}
+
+const encodeMessage = (message: JsonRpcMessage): Buffer => {
+  const body = Buffer.from(JSON.stringify(message), 'utf8');
+  const header = Buffer.from(`Content-Length: ${body.length}${HEADER_DELIMITER}`, 'utf8');
+  return Buffer.concat([header, body]);
+};
+
+export class StdioTransport implements McpTransport {
+  private readonly reader = new FramedMessageReader();
+  private readonly connection: McpConnection = {
+    id: 'stdio',
+    send: (message: JsonRpcMessage) => {
+      stdout.write(encodeMessage(message));
+    },
+  };
+
+  async listen(onMessage: (connection: McpConnection, message: JsonRpcMessage) => Promise<void>): Promise<void> {
+    stdin.on('data', async (chunk: Buffer) => {
+      await this.reader.push(chunk, async (message) => onMessage(this.connection, message));
+    });
+  }
+}

--- a/mcp-server/tsconfig.build.json
+++ b/mcp-server/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts"],
+  "compilerOptions": {}
+}

--- a/mcp-server/tsconfig.json
+++ b/mcp-server/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "include": ["src/**/*.ts"],
+  "compilerOptions": {
+    "outDir": "dist",
+    "declaration": true,
+    "lib": ["ESNext"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "allowJs": true,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitAny": true,
+    "strict": true,
+    "isolatedModules": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
       "bboard-cli",
       "bboard-ui",
       "api",
-      "contract"
+      "contract",
+      "mcp-server"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
I have extended the BBOARD example repo to add a 2 steps publication, the POSTER send the POST and it stays in a PENDING STATUS in the Pending SLOT, then ADMIN have to approve/reject, if approved it is published. Poster can withdraw if admin did not approved/rejected yet.

MCP server host HTTP and also STDIO so agents can interact with the contract as POSTERS, great example on how to run an MCP server and integrate agents to MIDNIGHT.

Added the proper menu items to work with the extension, the readme files, examples and TESTs... everything documented.

ENJOY!