### PR TITLE
feat: add expiration to posts in contract

### DIFF
--- a/api/src/common-types.ts
+++ b/api/src/common-types.ts
@@ -94,6 +94,12 @@ export type BBoardDerivedState = {
    * `owner` corresponds to the public key derived from `secretKey`, then `isOwner` is `true`.
    */
   readonly isOwner: boolean;
+
+  /**
+   * The expiration time of the current post, in seconds since epoch.
+   * Only meaningful when `state` is `OCCUPIED`. Zero when the board is vacant.
+   */
+  readonly postTimestamp: bigint;
 };
 
 // TODO: for some reason I needed to include "@midnight-ntwrk/wallet-sdk-address-format": "1.0.0-rc.1", should we bump in to rc-2 ?

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -138,7 +138,8 @@ export class BBoardAPI implements DeployedBBoardAPI {
   async post(message: string): Promise<void> {
     this.logger?.info(`postingMessage: ${message}`);
 
-    const txData = await this.deployedContract.callTx.post(message);
+    const nowSecs = Math.floor(Date.now() / 1000); // Epoc seconds
+    const txData = await this.deployedContract.callTx.post(message, BigInt(nowSecs));
 
     this.logger?.trace({
       transactionAdded: {

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -111,6 +111,7 @@ export class BBoardAPI implements DeployedBBoardAPI {
           message: ledgerState.message.value,
           sequence: ledgerState.sequence,
           isOwner: toHex(ledgerState.owner) === toHex(hashedSecretKey),
+          postTimestamp: ledgerState.postTimestamp,
         };
       },
     );

--- a/bboard-cli/src/index.ts
+++ b/bboard-cli/src/index.ts
@@ -154,6 +154,12 @@ const displayPrivateState = async (providers: BBoardProviders, logger: Logger): 
  * determine if the current user is the owner of the current message.
  */
 
+const formatDuration = (secs: bigint): string => {
+  const m = secs / 60n;
+  const s = secs % 60n;
+  return m > 0n ? `${m}m ${s}s` : `${s}s`;
+};
+
 const displayDerivedState = (ledgerState: BBoardDerivedState | undefined, logger: Logger) => {
   if (ledgerState === undefined) {
     logger.info(`No bulletin board state currently available`);
@@ -164,6 +170,19 @@ const displayDerivedState = (ledgerState: BBoardDerivedState | undefined, logger
     logger.info(`Current message is: '${latestMessage}'`);
     logger.info(`Current sequence is: ${ledgerState.sequence}`);
     logger.info(`Current owner is: '${ledgerState.isOwner ? 'you' : 'not you'}'`);
+    if (ledgerState.state === State.OCCUPIED && ledgerState.postTimestamp > 0n) {
+      const nowSecs = BigInt(Math.floor(Date.now() / 1000));
+      const ageSecs = nowSecs - (ledgerState.postTimestamp - 180n);
+      const remainingSecs = ledgerState.postTimestamp - nowSecs;
+      if (ageSecs > 0n) {
+        logger.info(`Post age: ${formatDuration(ageSecs)}`);
+      }
+      if (remainingSecs > 0n) {
+        logger.info(`Expires in: ${formatDuration(remainingSecs)}`);
+      } else {
+        logger.info(`Post expired ${formatDuration(-remainingSecs)} ago (can be removed by anyone)`);
+      }
+    }
   }
 };
 

--- a/bboard-ui/src/components/Board.tsx
+++ b/bboard-ui/src/components/Board.tsx
@@ -17,6 +17,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { type ContractAddress } from '@midnight-ntwrk/compact-runtime';
 import {
   Backdrop,
+  Box,
   CircularProgress,
   Card,
   CardActions,
@@ -238,27 +239,39 @@ export const Board: React.FC<Readonly<BoardProps>> = ({ boardDeployment$ }) => {
               <Skeleton variant="rectangular" width={245} height={160} />
             )}
           </CardContent>
-          <CardActions>
+          <CardActions sx={{ justifyContent: 'space-between', alignItems: 'center' }}>
             {deployedBoardAPI ? (
               <React.Fragment>
-                <IconButton
-                  title="Post message"
-                  data-testid="board-post-message-btn"
-                  disabled={boardState?.state === State.OCCUPIED || !messagePrompt?.length}
-                  onClick={onPostMessage}
-                >
-                  <WriteIcon />
-                </IconButton>
-                <IconButton
-                  title="Take down message"
-                  data-testid="board-take-down-message-btn"
-                  disabled={
-                    boardState?.state === State.VACANT || (boardState?.state === State.OCCUPIED && !boardState.isOwner)
-                  }
-                  onClick={onDeleteMessage}
-                >
-                  <DeleteIcon />
-                </IconButton>
+                <Box>
+                  <IconButton
+                    title="Post message"
+                    data-testid="board-post-message-btn"
+                    disabled={boardState?.state === State.OCCUPIED || !messagePrompt?.length}
+                    onClick={onPostMessage}
+                  >
+                    <WriteIcon />
+                  </IconButton>
+                  <IconButton
+                    title="Take down message"
+                    data-testid="board-take-down-message-btn"
+                    disabled={
+                      boardState?.state === State.VACANT ||
+                      (boardState?.state === State.OCCUPIED && !boardState.isOwner)
+                    }
+                    onClick={onDeleteMessage}
+                  >
+                    <DeleteIcon />
+                  </IconButton>
+                </Box>
+                {boardState?.state === State.OCCUPIED && boardState.postTimestamp > 0n && (
+                  <Typography variant="caption" color="text.secondary" textAlign="right">
+                    Expires{' '}
+                    {new Date(Number(boardState.postTimestamp) * 1000).toLocaleString(undefined, {
+                      dateStyle: 'short',
+                      timeStyle: 'short',
+                    })}
+                  </Typography>
+                )}
               </React.Fragment>
             ) : (
               <Skeleton variant="rectangular" width={80} height={20} />

--- a/bboard-ui/src/components/Board.tsx
+++ b/bboard-ui/src/components/Board.tsx
@@ -70,6 +70,15 @@ export const Board: React.FC<Readonly<BoardProps>> = ({ boardDeployment$ }) => {
   const [boardState, setBoardState] = useState<BBoardDerivedState>();
   const [messagePrompt, setMessagePrompt] = useState<string>();
   const [isWorking, setIsWorking] = useState(!!boardDeployment$);
+  const [now, setNow] = useState(() => BigInt(Math.floor(Date.now() / 1000)));
+
+  useEffect(() => {
+    const interval = setInterval(() => setNow(BigInt(Math.floor(Date.now() / 1000))), 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const isExpired =
+    boardState?.state === State.OCCUPIED && boardState.postTimestamp > 0n && now > boardState.postTimestamp;
 
   // Two simple callbacks that call `resolve(...)` to either deploy or join a bulletin board
   // contract. Since the `DeployedBoardContext` will create a new board and update the UI, we
@@ -252,11 +261,11 @@ export const Board: React.FC<Readonly<BoardProps>> = ({ boardDeployment$ }) => {
                     <WriteIcon />
                   </IconButton>
                   <IconButton
-                    title="Take down message"
+                    title={isExpired ? 'Remove expired post' : 'Take down message'}
                     data-testid="board-take-down-message-btn"
                     disabled={
                       boardState?.state === State.VACANT ||
-                      (boardState?.state === State.OCCUPIED && !boardState.isOwner)
+                      (boardState?.state === State.OCCUPIED && !boardState.isOwner && !isExpired)
                     }
                     onClick={onDeleteMessage}
                   >
@@ -264,8 +273,8 @@ export const Board: React.FC<Readonly<BoardProps>> = ({ boardDeployment$ }) => {
                   </IconButton>
                 </Box>
                 {boardState?.state === State.OCCUPIED && boardState.postTimestamp > 0n && (
-                  <Typography variant="caption" color="text.secondary" textAlign="right">
-                    Expires{' '}
+                  <Typography variant="caption" color={isExpired ? 'warning.main' : 'text.secondary'} textAlign="right">
+                    {isExpired ? 'Expired: ' : 'Expires: '}
                     {new Date(Number(boardState.postTimestamp) * 1000).toLocaleString(undefined, {
                       dateStyle: 'short',
                       timeStyle: 'short',

--- a/contract/src/bboard.compact
+++ b/contract/src/bboard.compact
@@ -30,24 +30,33 @@ export ledger sequence: Counter;
 
 export ledger owner: Bytes<32>;
 
+export ledger postTimestamp: Uint<64>;
+
 constructor() {
   state = State.VACANT;
+  postTimestamp = 0;
   message = none<Opaque<"string">>();
   sequence.increment(1);
 }
 
 witness localSecretKey(): Bytes<32>;
 
-export circuit post(newMessage: Opaque<"string">): [] {
+export circuit post(newMessage: Opaque<"string">, nowSecs: Uint<64>): [] {
   assert(state == State.VACANT, "Attempted to post to an occupied board");
+  assert(nowSecs > postTimestamp, "Attempted to post with an old/invalid timestamp value");
   owner = disclose(publicKey(localSecretKey(), sequence as Field as Bytes<32>));
   message = disclose(some<Opaque<"string">>(newMessage));
   state = State.OCCUPIED;
+  const expSecs = nowSecs + 180 as Field as Uint<64>; // expires in 3 mins
+  postTimestamp = disclose(expSecs);
 }
 
 export circuit takeDown(): Opaque<"string"> {
   assert(state == State.OCCUPIED, "Attempted to take down post from an empty board");
-  assert(owner == publicKey(localSecretKey(), sequence as Field as Bytes<32>), "Attempted to take down post, but not the current owner");
+  assert(kernel.blockTimeGreaterThan(postTimestamp) ||
+         owner == publicKey(localSecretKey(), sequence as Field as Bytes<32>),
+         "Attempted to take down post, but not the current owner and post didn't expired"
+         );
   const formerMsg = message.value;
   state = State.VACANT;
   sequence.increment(1);

--- a/contract/src/test/bboard-simulator.ts
+++ b/contract/src/test/bboard-simulator.ts
@@ -74,11 +74,12 @@ export class BBoardSimulator {
     return this.circuitContext.currentPrivateState;
   }
 
-  public post(message: string): Ledger {
+  public post(message: string, nowSecs: bigint): Ledger {
     // Update the current context to be the result of executing the circuit.
     this.circuitContext = this.contract.impureCircuits.post(
       this.circuitContext,
       message,
+      nowSecs,
     ).context;
     return ledger(this.circuitContext.currentQueryContext.state);
   }

--- a/contract/src/test/bboard-simulator.ts
+++ b/contract/src/test/bboard-simulator.ts
@@ -91,6 +91,13 @@ export class BBoardSimulator {
     return ledger(this.circuitContext.currentQueryContext.state);
   }
 
+  public setBlockTime(secondsSinceEpoch: bigint): void {
+    this.circuitContext.currentQueryContext.block = {
+      ...this.circuitContext.currentQueryContext.block,
+      secondsSinceEpoch,
+    };
+  }
+
   public publicKey(): Uint8Array {
     const sequence = convertFieldToBytes(
       32,

--- a/contract/src/test/bboard.test.ts
+++ b/contract/src/test/bboard.test.ts
@@ -41,6 +41,7 @@ describe("BBoard smart contract", () => {
     expect(initialLedgerState.message.value).toEqual("");
     expect(initialLedgerState.owner).toEqual(new Uint8Array(32));
     expect(initialLedgerState.state).toEqual(State.VACANT);
+    expect(initialLedgerState.postTimestamp).toEqual(0n);
     const initialPrivateState = simulator.getPrivateState();
     expect(initialPrivateState).toEqual({ secretKey: key });
   });
@@ -48,9 +49,10 @@ describe("BBoard smart contract", () => {
   it("lets you set a message", () => {
     const simulator = new BBoardSimulator(randomBytes(32));
     const initialPrivateState = simulator.getPrivateState();
+    const nowSecs = simulator.getLedger().postTimestamp + 60n;
     const message =
       "Szeth-son-son-Vallano, Truthless of Shinovar, wore white on the day he was to kill a king";
-    simulator.post(message);
+    simulator.post(message, nowSecs);
     // the private ledger state shouldn't change
     expect(initialPrivateState).toEqual(simulator.getPrivateState());
     // And all the correct things should have been updated in the public ledger state
@@ -60,15 +62,17 @@ describe("BBoard smart contract", () => {
     expect(ledgerState.message.value).toEqual(message);
     expect(ledgerState.owner).toEqual(simulator.publicKey());
     expect(ledgerState.state).toEqual(State.OCCUPIED);
+    expect(ledgerState.postTimestamp).toEqual(nowSecs + 180n);
   });
 
   it("lets you take down a message", () => {
     const simulator = new BBoardSimulator(randomBytes(32));
     const initialPrivateState = simulator.getPrivateState();
     const initialPublicKey = simulator.publicKey();
+    const nowSecs = simulator.getLedger().postTimestamp + 60n;
     const message =
       "Prince Raoden of Arelon awoke early that morning, completely unaware that he had been damned for all eternity.";
-    simulator.post(message);
+    simulator.post(message, nowSecs);
     simulator.takeDown();
     // the private ledger state shouldn't change
     expect(initialPrivateState).toEqual(simulator.getPrivateState());
@@ -80,15 +84,18 @@ describe("BBoard smart contract", () => {
     // Technically the circuit doesn't clear the previous owner
     expect(ledgerState.owner).toEqual(initialPublicKey);
     expect(ledgerState.state).toEqual(State.VACANT);
+    expect(ledgerState.postTimestamp).toEqual(nowSecs + 180n);
   });
 
   it("lets you post another message after taking down the first", () => {
     const simulator = new BBoardSimulator(randomBytes(32));
     const initialPrivateState = simulator.getPrivateState();
-    simulator.post("Life before Death.");
+    let nowSecs = simulator.getLedger().postTimestamp + 60n;
+    simulator.post("Life before Death.", nowSecs);
     simulator.takeDown();
     const message = "Strength before Weakness.";
-    simulator.post(message);
+    nowSecs = simulator.getLedger().postTimestamp + 60n;
+    simulator.post(message, nowSecs);
     // the private ledger state shouldn't change
     expect(initialPrivateState).toEqual(simulator.getPrivateState());
     // And all the correct things should have been updated in the public ledger state
@@ -102,11 +109,16 @@ describe("BBoard smart contract", () => {
 
   it("lets a different user post a message after taking down the first", () => {
     const simulator = new BBoardSimulator(randomBytes(32));
-    simulator.post("Remember, the past need not become our future as well.");
+    let nowSecs = simulator.getLedger().postTimestamp + 60n;
+    simulator.post(
+      "Remember, the past need not become our future as well.",
+      nowSecs,
+    );
     simulator.takeDown();
     simulator.switchUser(randomBytes(32));
     const message = "Joy was more than just an absence of discomfort.";
-    simulator.post(message);
+    nowSecs = simulator.getLedger().postTimestamp + 60n;
+    simulator.post(message, nowSecs);
     const ledgerState = simulator.getLedger();
     expect(ledgerState.sequence).toEqual(2n);
     expect(ledgerState.message.is_some).toEqual(true);
@@ -117,29 +129,35 @@ describe("BBoard smart contract", () => {
 
   it("doesn't let the same user post twice", () => {
     const simulator = new BBoardSimulator(randomBytes(32));
+    const nowSecs = simulator.getLedger().postTimestamp + 60n;
     simulator.post(
       "My name is Stephen Leeds, and I am perfectly sane. My hallucinations, however, are all quite mad.",
+      nowSecs,
     );
     expect(() =>
       simulator.post(
         "You should know by now that I've already had greatness. I traded it for mediocrity and some measure of sanity.",
+        nowSecs,
       ),
     ).toThrow("failed assert: Attempted to post to an occupied board");
   });
 
   it("doesn't let different users post twice", () => {
     const simulator = new BBoardSimulator(randomBytes(32));
-    simulator.post("Ash fell from the sky");
+    const nowSecs = simulator.getLedger().postTimestamp + 60n;
+    simulator.post("Ash fell from the sky", nowSecs);
     simulator.switchUser(randomBytes(32));
     expect(() =>
-      simulator.post("I am, unfortunately, the hero of ages."),
+      simulator.post("I am, unfortunately, the hero of ages.", nowSecs),
     ).toThrow("failed assert: Attempted to post to an occupied board");
   });
 
   it("doesn't let users take down someone elses posts", () => {
     const simulator = new BBoardSimulator(randomBytes(32));
+    const nowSecs = simulator.getLedger().postTimestamp + 60n;
     simulator.post(
       "Sometimes a hypocrite is nothing more than a man in the process of changing.",
+      nowSecs,
     );
     simulator.switchUser(randomBytes(32));
     expect(() => simulator.takeDown()).toThrow(

--- a/contract/src/test/bboard.test.ts
+++ b/contract/src/test/bboard.test.ts
@@ -164,4 +164,77 @@ describe("BBoard smart contract", () => {
       "failed assert: Attempted to take down post, but not the current owner",
     );
   });
+
+  it("doesn't let a non-owner take down a post before it expires", () => {
+    const simulator = new BBoardSimulator(randomBytes(32));
+    const nowSecs = simulator.getLedger().postTimestamp + 60n;
+    simulator.post(
+      "The most important step a man can take is not the first one, is it? It's the next one.",
+      nowSecs,
+    );
+    // postTimestamp is nowSecs + 180; set block time strictly before that
+    const postTimestamp = simulator.getLedger().postTimestamp;
+    simulator.setBlockTime(postTimestamp - 1n);
+    simulator.switchUser(randomBytes(32));
+    expect(() => simulator.takeDown()).toThrow(
+      "failed assert: Attempted to take down post, but not the current owner",
+    );
+  });
+
+  it("lets the original poster take down their own post before it expires", () => {
+    const simulator = new BBoardSimulator(randomBytes(32));
+    const initialPublicKey = simulator.publicKey();
+    const nowSecs = simulator.getLedger().postTimestamp + 60n;
+    const message =
+      "I am not ashamed of what I am. I am not afraid of what I know.";
+
+    simulator.post(message, nowSecs);
+    // set block time strictly before expiration
+    const postTimestamp = simulator.getLedger().postTimestamp;
+    simulator.setBlockTime(postTimestamp - 1n);
+    simulator.takeDown();
+    const ledgerState = simulator.getLedger();
+    expect(ledgerState.sequence).toEqual(2n);
+    expect(ledgerState.state).toEqual(State.VACANT);
+    expect(ledgerState.message.is_some).toEqual(false);
+    expect(ledgerState.owner).toEqual(initialPublicKey);
+  });
+
+  it("lets anyone remove an expired post", () => {
+    const ownerSimulator = new BBoardSimulator(randomBytes(32));
+    const nowSecs = ownerSimulator.getLedger().postTimestamp + 60n;
+    ownerSimulator.post(
+      "Somebody has to start. Somebody has to step forward and do what is right.",
+      nowSecs,
+    );
+    // advance block time past expiration
+    const postTimestamp = ownerSimulator.getLedger().postTimestamp;
+    ownerSimulator.setBlockTime(postTimestamp + 1n);
+    ownerSimulator.switchUser(randomBytes(32));
+    ownerSimulator.takeDown();
+    const ledgerState = ownerSimulator.getLedger();
+    expect(ledgerState.state).toEqual(State.VACANT);
+    expect(ledgerState.message.is_some).toEqual(false);
+  });
+
+  it("increments sequence counter correctly after expiration-based takedown", () => {
+    const simulator = new BBoardSimulator(randomBytes(32));
+    expect(simulator.getLedger().sequence).toEqual(1n);
+    let nowSecs = simulator.getLedger().postTimestamp + 60n;
+    simulator.post("There's always another secret.", nowSecs);
+    expect(simulator.getLedger().sequence).toEqual(1n);
+    // expire the post and have a non-owner take it down
+    const postTimestamp = simulator.getLedger().postTimestamp;
+    simulator.setBlockTime(postTimestamp + 1n);
+    simulator.switchUser(randomBytes(32));
+    simulator.takeDown();
+    expect(simulator.getLedger().sequence).toEqual(2n);
+    // post again (with the new user who took it down) and verify sequence stays at 2
+    nowSecs = simulator.getLedger().postTimestamp + 60n;
+    simulator.post("I'm going to do something slightly dramatic.", nowSecs);
+    expect(simulator.getLedger().sequence).toEqual(2n);
+    // take down the second post and verify sequence increments to 3
+    simulator.takeDown();
+    expect(simulator.getLedger().sequence).toEqual(3n);
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,7 @@
         "node-stdlib-browser": "^1.3.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "react-router-dom": "^7.14.0"
+        "react-router-dom": "7.14.0"
       },
       "devDependencies": {
         "@swc/core": "^1.15.11",


### PR DESCRIPTION
# Add post expiration to the bulletin board

Posts now expire after 3 minutes:
- Once a post has expired, anyone can remove it — not just the original poster.
- Before expiration, only the owner can take it down.

Changes made:
- Contract:
  - Added a `postTimestamp` ledger field to track when each post expires.
  - `post` now takes a `nowSecs` timestamp argument and validates it is more recent than the previous post (prevents replay).
  - `takeDown` now allows removal if the caller is the owner or the block time has passed the expiration timestamp — whichever comes first.
- API             
  - `post()` automatically passes the current time (epoch seconds) to the contract, so callers don't need to handle it.
- Tests
  - Added `setBlockTime` to the simulator to allow tests to control the on-chain clock.
  - New test cases:
    - A non-owner cannot remove a post before it expires.
    - The original poster can still take down their post early.
    - Anyone can remove a post after it expires.
    - The sequence counter increments correctly through both the normal and expiration-based take-down paths.

- CLI
  - The "display derived state" option now shows two additional lines when a board is occupied:
    - Post age — how long ago the message was posted.
    - Expires in / Expired X ago — how much time is left, or how long ago it expired (with a note that the post can be removed by anyone once expired).

- UI
  - The post card's action bar now shows the expiration date/time in the user's local timezone (e.g. "Expires 4/21/26, 4:30 PM") on the right side when a board is occupied.
  - When a non-owned post expires, it automatically enables the button to take down the post.