### PR TITLE
fix(bboard-cli): resolve config path with fileURLToPath (handles spaces in path)

### DIFF
--- a/bboard-cli/src/config.ts
+++ b/bboard-cli/src/config.ts
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   EnvironmentConfiguration,
   getTestEnvironment,
@@ -32,7 +33,7 @@ export interface Config {
   readonly generateDust: boolean;
 }
 
-export const currentDir = path.resolve(new URL(import.meta.url).pathname, '..');
+export const currentDir = path.resolve(fileURLToPath(import.meta.url), '..');
 
 export class StandaloneConfig implements Config {
   getEnvironment(logger: Logger): TestEnvironment {


### PR DESCRIPTION
## Problem

`bboard-cli/src/config.ts` builds `currentDir` with `new URL(import.meta.url).pathname`. When the project path contains a space, the space stays percent-encoded as %20 (e.g. `/Users/me/Midnight code/...` becomes `/Users/me/Midnight%20code/...`). That path doesn't exist on disk, so the ZK config lookup fails at runtime with `ZKConfigurationReadError: Failed to read verifier key`.

## Fix

Use `fileURLToPath(import.meta.url)` from `node:url`, which decodes the file URL to a real filesystem path. One-line change plus the import. Fixes the failure for anyone whose checkout lives under a directory with a space in the name.