### PR TITLE
Fix spaces-in-path bug in CLI config

### DIFF
--- a/bboard-cli/src/config.ts
+++ b/bboard-cli/src/config.ts
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   EnvironmentConfiguration,
   getTestEnvironment,
@@ -31,7 +32,7 @@ export interface Config {
   readonly generateDust: boolean;
 }
 
-export const currentDir = path.resolve(new URL(import.meta.url).pathname, '..');
+export const currentDir = path.resolve(fileURLToPath(import.meta.url), '..');
 
 export class StandaloneConfig implements Config {
   getEnvironment(logger: Logger): TestEnvironment {


### PR DESCRIPTION
bboard-cli/src/config.ts builds currentDir with new URL(import.meta.url).pathname, which URL-encodes spaces as %20. On any project path containing a space (like the default macOS ~/Documents/...), currentDir resolves with a literal %20 and the CLI cannot find its log dir or managed ZK config, so a fresh clone fails to run. Fix: use fileURLToPath(import.meta.url), which decodes the path correctly whether or not it contains spaces.