### PR TITLE
chore(ci): pin npm to 12.0.2 and add supply-chain cooldown

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
       # See https://github.com/npm/cli/issues/4828
       - name: Update NPM
         run: |
-          npm install -g npm@latest
+          npm install -g npm@12.0.2
           npm --version
 
       # We use --legacy-peer-deps because as of v3.4.1 vite-plugin-wasm doesn't play well with vite 7

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,7 @@
 # Temporary, until vite-plugin-wasm supports vite 7
 legacy-peer-deps = true
+# Supply-chain cooldown: refuse dependency versions published <7 days ago (npm 12+).
+# Own packages are exempt so same-day @midnight-ntwrk releases stay installable.
+min-release-age=7
+min-release-age-exclude[]=@midnight-ntwrk/*
+min-release-age-exclude[]=@midnightntwrk/*


### PR DESCRIPTION
Supply-chain hardening following the 2026-08-04 keyv/cacheable npm worm (868+ packages compromised via `preinstall` payloads published through legitimate maintainer accounts).

- Pin the npm CLI to 12.0.2 in CI (npm 12 blocks dependency lifecycle scripts by default behind `allowScripts`) instead of floating `npm@latest`/setup-node default
- Bump `node-version` where npm 12 requires it (engines: `^22.22.2 || ^24.15.0 || >=26`)
- Add `.npmrc` cooldown: `min-release-age=7` so freshly-published (potentially wormed) versions can't resolve for 7 days; `@midnight-ntwrk/*` and `@midnightntwrk/*` exempt so same-day internal releases still install
- Renovate: npm CLI pins in workflows/Earthfiles are matched by new custom managers in `midnightntwrk/renovate-config`, so this pin stays bumpable automatically
