### PR TITLE
fix(ci): pin npm-installed CI tool versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
       # See https://github.com/npm/cli/issues/4828
       - name: Update NPM
         run: |
-          npm install -g npm@latest
+          npm install -g npm@12.0.2
           npm --version
 
       # We use --legacy-peer-deps because as of v3.4.1 vite-plugin-wasm doesn't play well with vite 7


### PR DESCRIPTION
Closes #1527

Pins floating-version npm tool installs in workflows to exact versions (vercel 58.7.1 / npm 12.0.2 as applicable). Floating tags execute whatever the registry serves at run time; pinning closes that window.

AI-assistance disclosure: prepared with AI assistance (Claude). This repo has the legacy `ai-assisted` label (applied) but not the canonical `bot:ai-assisted` — repo needs the org label standardization pass.